### PR TITLE
Retrofitting Promises to existing interfaces

### DIFF
--- a/packages/pg-model/lib/Model/index.js
+++ b/packages/pg-model/lib/Model/index.js
@@ -82,7 +82,19 @@ class Model {
     scriptRunner(this, script, callback)
   }
 
-  findById (id, callback) {
+  findById (id, callback = NotSet) {
+    if (callback === NotSet) {
+      return new Promise((resolve, reject) => {
+        this.findById(id, (err, result) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(result)
+          }
+        })
+      })
+    }
+
     if (!_.isArray(id)) {
       id = [id]
     }
@@ -102,7 +114,19 @@ class Model {
     )
   }
 
-  find (options, callback) {
+  find (options, callback = NotSet) {
+    if (callback === NotSet) {
+      return new Promise((resolve, reject) => {
+        this.find(options, (err, result) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve(result)
+          }
+        })
+      })
+    } // if ...
+
     const doc = {}
     this.finder.find(
       doc,
@@ -117,7 +141,19 @@ class Model {
     )
   }
 
-  findOne (options, callback) {
+  findOne (options, callback = NotSet) {
+    if (callback === NotSet) {
+      return new Promise((resolve, reject) => {
+        this.findOne(options, (err, result) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve(result)
+          }
+        })
+      })
+    } // if ...
+
     options.limit = 1
     const doc = {}
     this.finder.find(

--- a/packages/pg-model/lib/Model/index.js
+++ b/packages/pg-model/lib/Model/index.js
@@ -179,7 +179,19 @@ class Model {
     return id
   }
 
-  update (doc, options, callback) {
+  update (doc, options, callback = NotSet) {
+    if (callback === NotSet) {
+      return new Promise((resolve, reject) => {
+        this.update(doc, options, (err, result) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve(result)
+          }
+        })
+      })
+    } // if ...
+
     options.destroyMissingSubDocs = false
     options.setMissingPropertiesToNull = true
     const script = [{statement: 'BEGIN'}]

--- a/packages/pg-model/lib/Model/index.js
+++ b/packages/pg-model/lib/Model/index.js
@@ -230,7 +230,18 @@ class Model {
     scriptRunner(this, script, callback)
   }
 
-  upsert (jsonData, options, callback) {
+  upsert (jsonData, options, callback = NotSet) {
+    if (callback === NotSet) {
+      return new Promise((resolve, reject) => {
+        this.upsert(jsonData, options, (err, result) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve(result)
+          }
+        })
+      })
+    }
     options.upsert = true
     const script = [{statement: 'BEGIN'}]
     this.creator.addStatements(

--- a/packages/pg-model/lib/Model/index.js
+++ b/packages/pg-model/lib/Model/index.js
@@ -73,11 +73,13 @@ class Model {
     this.creator = new Creator(this)
     this.destroyer = new Destroyer(this)
     this.updater = new Updater(this)
+
+    this.promised = (...args) => promised(this, ...args)
   }
 
   create (jsonData, options = { }, callback = NotSet) {
     if (callback === NotSet) {
-      return promised(this, this.create, jsonData, options)
+      return this.promised(this.create, jsonData, options)
     } // if ...
 
     options.upsert = false
@@ -88,7 +90,7 @@ class Model {
 
   findById (id, callback = NotSet) {
     if (callback === NotSet) {
-      return promised(this, this.findById, id)
+      return this.promised(this.findById, id)
     }
 
     if (!_.isArray(id)) {
@@ -112,7 +114,7 @@ class Model {
 
   find (options, callback = NotSet) {
     if (callback === NotSet) {
-      return promised(this, this.find, options)
+      return this.promised(this.find, options)
     } // if ...
 
     const doc = {}
@@ -131,7 +133,7 @@ class Model {
 
   findOne (options, callback = NotSet) {
     if (callback === NotSet) {
-      return promised(this, this.findOne, options)
+      return this.promised(this.findOne, options)
     } // if ...
 
     options.limit = 1
@@ -161,7 +163,7 @@ class Model {
 
   update (doc, options, callback = NotSet) {
     if (callback === NotSet) {
-      return promised(this, this.update, doc, options)
+      return this.promised(this.update, doc, options)
     } // if ...
 
     options.destroyMissingSubDocs = false
@@ -177,7 +179,7 @@ class Model {
 
   patch (doc, options, callback = NotSet) {
     if (callback === NotSet) {
-      return promised(this, this.patch, doc, options)
+      return this.promised(this.patch, doc, options)
     } // if ...
 
     const script = [{statement: 'BEGIN'}]
@@ -195,7 +197,7 @@ class Model {
 
   upsert (jsonData, options, callback = NotSet) {
     if (callback === NotSet) {
-      return promised(this, this.upsert, jsonData, options)
+      return this.promised(this.upsert, jsonData, options)
     }
     options.upsert = true
     const script = [{statement: 'BEGIN'}]
@@ -209,7 +211,7 @@ class Model {
 
   destroyById (id, callback = NotSet) {
     if (callback === NotSet) {
-      return promised(this, this.destroyById, id)
+      return this.promised(this.destroyById, id)
     }
 
     if (!_.isArray(id)) {

--- a/packages/pg-model/lib/Model/index.js
+++ b/packages/pg-model/lib/Model/index.js
@@ -7,6 +7,8 @@ const Creator = require('./actions/Creator')
 const Destroyer = require('./actions/Destroyer')
 const Updater = require('./actions/Updater')
 
+const NotSet = 'NetSet'
+
 class Model {
   constructor (components, options) {
     const _this = this
@@ -61,7 +63,19 @@ class Model {
     this.updater = new Updater(this)
   }
 
-  create (jsonData, options, callback) {
+  create (jsonData, options = { }, callback = NotSet) {
+    if (callback === NotSet) {
+      return new Promise((resolve, reject) => {
+        this.create(jsonData, options, (err, result) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve(result)
+          }
+        })
+      })
+    } // if ...
+
     options.upsert = false
     const script = [{statement: 'BEGIN'}]
     this.creator.addStatements(script, jsonData, options)

--- a/packages/pg-model/lib/Model/index.js
+++ b/packages/pg-model/lib/Model/index.js
@@ -203,7 +203,20 @@ class Model {
     scriptRunner(this, script, callback)
   }
 
-  patch (doc, options, callback) {
+  patch (doc, options, callback = NotSet) {
+    if (callback === NotSet) {
+      return new Promise((resolve, reject) => {
+        this.patch(doc, options, (err, result) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve(result)
+          }
+        })
+      })
+    } // if ...
+
+
     const script = [{statement: 'BEGIN'}]
 
     options.destroyMissingSubDocsv = false

--- a/packages/pg-model/lib/Model/index.js
+++ b/packages/pg-model/lib/Model/index.js
@@ -252,7 +252,19 @@ class Model {
     scriptRunner(this, script, callback)
   }
 
-  destroyById (id, callback) {
+  destroyById (id, callback = NotSet) {
+    if (callback === NotSet) {
+      return new Promise((resolve, reject) => {
+        this.destroyById(id, (err, result) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve(result)
+          }
+        })
+      })
+    }
+
     if (!_.isArray(id)) {
       id = [id]
     }

--- a/packages/pg-model/lib/Model/index.js
+++ b/packages/pg-model/lib/Model/index.js
@@ -9,6 +9,18 @@ const Updater = require('./actions/Updater')
 
 const NotSet = 'NetSet'
 
+function promised(obj, fn, ...args) {
+  return new Promise((resolve, reject) => {
+    fn.call(obj, ...args, (err, result) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(result)
+      }
+    })
+  })
+} // promised
+
 class Model {
   constructor (components, options) {
     const _this = this
@@ -65,15 +77,7 @@ class Model {
 
   create (jsonData, options = { }, callback = NotSet) {
     if (callback === NotSet) {
-      return new Promise((resolve, reject) => {
-        this.create(jsonData, options, (err, result) => {
-          if (err) {
-            reject(err)
-          } else {
-            resolve(result)
-          }
-        })
-      })
+      return promised(this, this.create, jsonData, options)
     } // if ...
 
     options.upsert = false
@@ -84,15 +88,7 @@ class Model {
 
   findById (id, callback = NotSet) {
     if (callback === NotSet) {
-      return new Promise((resolve, reject) => {
-        this.findById(id, (err, result) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(result)
-          }
-        })
-      })
+      return promised(this, this.findById, id)
     }
 
     if (!_.isArray(id)) {
@@ -116,15 +112,7 @@ class Model {
 
   find (options, callback = NotSet) {
     if (callback === NotSet) {
-      return new Promise((resolve, reject) => {
-        this.find(options, (err, result) => {
-          if (err) {
-            reject(err)
-          } else {
-            resolve(result)
-          }
-        })
-      })
+      return promised(this, this.find, options)
     } // if ...
 
     const doc = {}
@@ -143,15 +131,7 @@ class Model {
 
   findOne (options, callback = NotSet) {
     if (callback === NotSet) {
-      return new Promise((resolve, reject) => {
-        this.findOne(options, (err, result) => {
-          if (err) {
-            reject(err)
-          } else {
-            resolve(result)
-          }
-        })
-      })
+      return promised(this, this.findOne, options)
     } // if ...
 
     options.limit = 1
@@ -181,15 +161,7 @@ class Model {
 
   update (doc, options, callback = NotSet) {
     if (callback === NotSet) {
-      return new Promise((resolve, reject) => {
-        this.update(doc, options, (err, result) => {
-          if (err) {
-            reject(err)
-          } else {
-            resolve(result)
-          }
-        })
-      })
+      return promised(this, this.update, doc, options)
     } // if ...
 
     options.destroyMissingSubDocs = false
@@ -205,17 +177,8 @@ class Model {
 
   patch (doc, options, callback = NotSet) {
     if (callback === NotSet) {
-      return new Promise((resolve, reject) => {
-        this.patch(doc, options, (err, result) => {
-          if (err) {
-            reject(err)
-          } else {
-            resolve(result)
-          }
-        })
-      })
+      return promised(this, this.patch, doc, options)
     } // if ...
-
 
     const script = [{statement: 'BEGIN'}]
 
@@ -232,15 +195,7 @@ class Model {
 
   upsert (jsonData, options, callback = NotSet) {
     if (callback === NotSet) {
-      return new Promise((resolve, reject) => {
-        this.upsert(jsonData, options, (err, result) => {
-          if (err) {
-            reject(err)
-          } else {
-            resolve(result)
-          }
-        })
-      })
+      return promised(this, this.upsert, jsonData, options)
     }
     options.upsert = true
     const script = [{statement: 'BEGIN'}]
@@ -254,15 +209,7 @@ class Model {
 
   destroyById (id, callback = NotSet) {
     if (callback === NotSet) {
-      return new Promise((resolve, reject) => {
-        this.destroyById(id, (err, result) => {
-          if (err) {
-            reject(err)
-          } else {
-            resolve(result)
-          }
-        })
-      })
+      return promised(this, this.destroyById, id)
     }
 
     if (!_.isArray(id)) {

--- a/packages/pg-model/lib/Model/index.js
+++ b/packages/pg-model/lib/Model/index.js
@@ -9,7 +9,7 @@ const Updater = require('./actions/Updater')
 
 const NotSet = 'NetSet'
 
-function promised(obj, fn, ...args) {
+function promised (obj, fn, ...args) {
   return new Promise((resolve, reject) => {
     fn.call(obj, ...args, (err, result) => {
       if (err) {

--- a/packages/pg-model/test/test-promises.js
+++ b/packages/pg-model/test/test-promises.js
@@ -1,0 +1,977 @@
+/* eslint-env mocha */
+
+'use strict'
+
+const pg = require('pg')
+const process = require('process')
+const sqlScriptRunner = require('./fixtures/sql-script-runner')
+const pgModel = require('./../lib')
+const empty = require('./fixtures/empty.json')
+const planets = require('./fixtures/planets.json')
+const pgDiffSync = require('pg-diff-sync')
+const async = require('async')
+const chai = require('chai')
+const chaiSubset = require('chai-subset')
+chai.use(chaiSubset)
+const expect = chai.expect
+const assert = require('assert')
+
+describe('Test promise API', function () {
+  let client
+  let models
+  let phobosId
+  let stickneyId
+
+  it('Should create a new pg client', function () {
+    client = new pg.Client(process.env.PG_CONNECTION_STRING)
+    client.connect()
+  })
+
+  it('Should initially drop-cascade the pg_model_test schema, if one exists', function (done) {
+    sqlScriptRunner(
+      [
+        'uninstall.sql',
+        'install.sql'
+      ],
+      client,
+      function (err) {
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it('Should install test database objects', function (done) {
+    async.eachSeries(
+      pgDiffSync(
+        empty,
+        planets
+      ),
+      function (statement, cb) {
+        client.query(
+          statement,
+          function (e) {
+            if (e) {
+              console.error(statement)
+              cb(e)
+            } else {
+              cb()
+            }
+          }
+        )
+      },
+      function (err) {
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it('should get some model instances', function () {
+    models = pgModel(
+      {
+        client: client,
+        dbStructure: planets
+      }
+    )
+  })
+
+  it('should create a new person', function () {
+    return models.pgmodelTest.person.create(
+      {
+        employeeNo: 1,
+        firstName: 'Homer',
+        lastName: 'Simpson',
+        age: 39
+      },
+      {}
+    ).then(idProperties =>
+      expect(idProperties).to.eql(
+        {
+          idProperties:
+          {
+            employeeNo: '1'
+          }
+        }
+      )
+    )
+  })
+
+  it('should create multiple new people', function () {
+    return models.pgmodelTest.person.create(
+      [
+        {
+          employeeNo: 2,
+          firstName: 'Maggie',
+          lastName: 'Simpson'
+        },
+        {
+          employeeNo: 3,
+          firstName: 'Lisa',
+          lastName: 'Simpson',
+          age: 8
+        },
+        {
+          employeeNo: 4,
+          firstName: 'Marge',
+          lastName: 'Simpson',
+          age: 36
+        },
+        {
+          employeeNo: 5,
+          firstName: 'Bart',
+          lastName: 'Simpson',
+          age: 10
+        }
+      ]
+    )
+  })
+
+  it('should fail creating a new person with an already-used primary key', function () {
+    return models.pgmodelTest.person.create(
+      {
+        employeeNo: 1,
+        firstName: 'Ned',
+        lastName: 'Flanders',
+        age: 60
+      },
+      {}
+    )
+      .then(() => assert(false))
+      .catch(err => {
+          expect(err).to.containSubset(
+            {
+              'code': '23505',
+              'constraint': 'person_pkey',
+              'detail': 'Key (employee_no)=(1) already exists.',
+              'name': 'error',
+              'schema': 'pgmodel_test',
+              'severity': 'ERROR',
+              'table': 'person'
+            }
+          )
+        }
+      )
+  })
+
+  it('should fail creating new people with an already-used primary key', function () {
+    return models.pgmodelTest.person.create(
+      [
+        {
+          employeeNo: 6,
+          firstName: 'Ned',
+          lastName: 'Flanders',
+          age: 60
+        },
+        {
+          employeeNo: 2,
+          firstName: 'Maude',
+          lastName: 'Flanders'
+        }
+      ],
+      {}
+    )
+      .then(() => assert(false))
+      .catch(err => {
+        expect(err).to.containSubset(
+          {
+            'code': '23505',
+            'constraint': 'person_pkey',
+            'detail': 'Key (employee_no)=(2) already exists.',
+            'name': 'error',
+            'schema': 'pgmodel_test',
+            'severity': 'ERROR',
+            'table': 'person'
+          }
+        )
+      }
+    )
+  })
+
+  it('should find a person via primary key', function (done) {
+    models.pgmodelTest.person.findById(
+      3,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'employeeNo': '3',
+            'firstName': 'Lisa',
+            'lastName': 'Simpson',
+            'age': 8
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it("should fail finding a person that's not there", function (done) {
+    models.pgmodelTest.person.findById(
+      6,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.equal(undefined)
+        done()
+      }
+    )
+  })
+
+  it('should find 5 people, youngest first', function (done) {
+    models.pgmodelTest.person.find(
+      {
+        orderBy: ['age']
+      },
+      function (err, doc) {
+        expect(err).to.equal(null)
+
+        expect(doc[0].age).to.equal(8)
+        expect(doc[1].age).to.equal(10)
+        expect(doc[2].age).to.equal(36)
+        expect(doc[3].age).to.equal(39)
+        expect(doc[4].age).to.equal(null)
+        expect(doc).to.containSubset(
+          [
+            {
+              'age': 8,
+              'employeeNo': '3',
+              'firstName': 'Lisa',
+              'lastName': 'Simpson'
+            },
+            {
+              'age': 10,
+              'employeeNo': '5',
+              'firstName': 'Bart',
+              'lastName': 'Simpson'
+            },
+            {
+              'age': 36,
+              'employeeNo': '4',
+              'firstName': 'Marge',
+              'lastName': 'Simpson'
+            },
+            {
+              'age': 39,
+              'employeeNo': '1',
+              'firstName': 'Homer',
+              'lastName': 'Simpson'
+            },
+            {
+              'age': null,
+              'employeeNo': '2',
+              'firstName': 'Maggie',
+              'lastName': 'Simpson'
+            }
+          ]
+        )
+        done()
+      }
+    )
+  })
+
+  it('should find 3 people, eldest first', function (done) {
+    models.pgmodelTest.person.find(
+      {
+        orderBy: ['-age'],
+        nullsLast: true
+      },
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc[0].age).to.equal(39)
+        expect(doc[1].age).to.equal(36)
+        expect(doc[2].age).to.equal(10)
+        expect(doc[3].age).to.equal(8)
+        expect(doc[4].age).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it('should find Bart by name', function (done) {
+    models.pgmodelTest.person.find(
+      {
+        where: {
+          firstName: {equals: 'Bart'},
+          lastName: {equals: 'Simpson'}
+        }
+      },
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.have.length(1)
+        expect(doc).to.containSubset(
+          [
+            {
+              'age': 10,
+              'employeeNo': '5',
+              'firstName': 'Bart',
+              'lastName': 'Simpson'
+            }
+          ]
+        )
+
+        done()
+      }
+    )
+  })
+
+  it('should find Bart and Lisa (eldest with limit 2/offset 2)', function (done) {
+    models.pgmodelTest.person.find(
+      {
+        orderBy: ['-age'],
+        nullsLast: true,
+        limit: 2,
+        offset: 2
+      },
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.have.length(2)
+        expect(doc[0].employeeNo).to.eql('5')
+        expect(doc[1].employeeNo).to.eql('3')
+        expect(doc).to.containSubset(
+          [
+            {
+              'age': 10,
+              'employeeNo': '5',
+              'firstName': 'Bart',
+              'lastName': 'Simpson'
+            },
+            {
+              'age': 8,
+              'employeeNo': '3',
+              'firstName': 'Lisa',
+              'lastName': 'Simpson'
+            }
+          ]
+        )
+        done()
+      }
+    )
+  })
+
+  it('should get the second youngest known person (Marge)', function (done) {
+    models.pgmodelTest.person.findOne(
+      {
+        orderBy: ['age'],
+        nullsLast: true,
+        offset: 1
+      },
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'age': 10,
+            'employeeNo': '5',
+            'firstName': 'Bart',
+            'lastName': 'Simpson'
+          }
+        )
+
+        done()
+      }
+    )
+  })
+
+  it('should get one Homer by name', function (done) {
+    models.pgmodelTest.person.findOne(
+      {
+        where: {
+          firstName: {equals: 'Homer'},
+          lastName: {equals: 'Simpson'}
+        }
+      },
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'age': 39,
+            'employeeNo': '1',
+            'firstName': 'Homer',
+            'lastName': 'Simpson'
+          }
+        )
+
+        done()
+      }
+    )
+  })
+
+  it("shouldn't get one missing person", function (done) {
+    models.pgmodelTest.person.findOne(
+      {
+        where: {
+          firstName: {equals: 'Ned'},
+          lastName: {equals: 'Flanders'}
+        }
+      },
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.equal(undefined)
+        done()
+      }
+    )
+  })
+
+  it("should update Maggie's age to 1", function (done) {
+    models.pgmodelTest.person.update(
+      {
+        employeeNo: 2,
+        age: 1,
+        firstName: 'Maggie',
+        lastName: 'Simpson'
+      },
+      {},
+      function (err) {
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it('should find Maggie has an age now', function (done) {
+    models.pgmodelTest.person.findById(
+      2,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'employeeNo': '2',
+            'firstName': 'Maggie',
+            'lastName': 'Simpson',
+            'age': 1
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should update Maggie again, but this time without an age', function (done) {
+    models.pgmodelTest.person.update(
+      {
+        employeeNo: 2,
+        firstName: 'Maggie',
+        lastName: 'Simpson'
+      },
+      {},
+      function (err, doc) {
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it("should find Maggie's age has gone again", function (done) {
+    models.pgmodelTest.person.findById(
+      2,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'employeeNo': '2',
+            'firstName': 'Maggie',
+            'lastName': 'Simpson',
+            'age': null
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should patch Maggie to Margaret', function (done) {
+    models.pgmodelTest.person.patch(
+      {
+        employeeNo: 2,
+        firstName: 'Margaret'
+      },
+      {},
+      function (err, doc) {
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it('should find Maggie is now a Margaret', function (done) {
+    models.pgmodelTest.person.findById(
+      2,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'employeeNo': '2',
+            'firstName': 'Margaret',
+            'lastName': 'Simpson',
+            'age': null
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should delete Maggie/Margaret by via her id', function (done) {
+    models.pgmodelTest.person.destroyById(
+      2,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it('should fail getting a deleted record', function (done) {
+    models.pgmodelTest.person.findById(
+      2,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.equal(undefined)
+        done()
+      }
+    )
+  })
+
+  it('should upsert (insert) Grampa', function (done) {
+    models.pgmodelTest.person.upsert(
+      {
+        employeeNo: 10,
+        firstName: 'Abe',
+        lastName: 'Simpson',
+        age: 82
+      },
+      {},
+      function (err, idProperties) {
+        expect(idProperties).to.eql(
+          {
+            idProperties: {
+              employeeNo: '10'
+            }
+          }
+        )
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it('should find Grampa has been inserted via upsert', function (done) {
+    models.pgmodelTest.person.findById(
+      10,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'employeeNo': '10',
+            'firstName': 'Abe',
+            'lastName': 'Simpson',
+            'age': 82
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should upsert (update) Grampa', function (done) {
+    models.pgmodelTest.person.upsert(
+      {
+        employeeNo: 10,
+        firstName: 'Abraham',
+        lastName: 'Simpson',
+        age: 83
+      },
+      {},
+      function (err, doc) {
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it('should find Grampa has now been updates via upsert', function (done) {
+    models.pgmodelTest.person.findById(
+      10,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'employeeNo': '10',
+            'firstName': 'Abraham',
+            'lastName': 'Simpson',
+            'age': 83
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should now upsert (update) Grampa, resetting his name', function (done) {
+    models.pgmodelTest.person.upsert(
+      {
+        employeeNo: 10,
+        firstName: 'Abe',
+        lastName: 'Simpson'
+      },
+      {
+        setMissingPropertiesToNull: false
+      },
+      function (err, doc) {
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it('should find Grampa again, with his age preserved and an updated name', function (done) {
+    models.pgmodelTest.person.findById(
+      10,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'employeeNo': '10',
+            'firstName': 'Abe',
+            'lastName': 'Simpson',
+            'age': 83
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should upsert (update) Grampa again, but turn age to null', function (done) {
+    models.pgmodelTest.person.upsert(
+      {
+        employeeNo: 10,
+        firstName: 'Abraham',
+        lastName: 'Simpson'
+      },
+      {},
+      function (err, doc) {
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it('should find Grampa again, but now with a null age', function (done) {
+    models.pgmodelTest.person.findById(
+      10,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'employeeNo': '10',
+            'firstName': 'Abraham',
+            'lastName': 'Simpson',
+            'age': null
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should create mars, with two moons and a few craters', function (done) {
+    models.pgmodelTest.planets.create(
+      {
+        name: 'mars',
+        title: 'Mars',
+        type: 'Terrestrial',
+        diameter: 6700,
+        color: 'red',
+        url: 'http://en.wikipedia.org/wiki/Mars',
+        otherFacts: {
+          radius: 3390,
+          surfacePressure: '0.636 (0.4–0.87) kPa; 0.00628 atm',
+          equatorialRotationVelocity: '868.22 km/h (241.17 m/s)'
+        },
+        moons: [
+          {
+            title: 'Phobos',
+            discoveredBy: 'Asaph Hall',
+            discoveryYear: 1800,
+            craters: [
+              {
+                title: 'Stickney',
+                diameter: 9
+              }
+            ]
+          },
+          {
+            title: 'Deimos',
+            discoveredBy: 'Asaph Hall',
+            discoveryYear: 1800
+          }
+        ]
+      },
+      {},
+      function (err, idProperties) {
+        expect(err).to.equal(null)
+        expect(idProperties).to.eql(
+          {
+            idProperties: {
+              name: 'mars'
+            }
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should find Mars via primary key', function (done) {
+    models.pgmodelTest.planets.findById(
+      'mars',
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'name': 'mars',
+            'title': 'Mars',
+            'type': 'Terrestrial',
+            'diameter': '6700',
+            'color': 'red',
+            'url': 'http://en.wikipedia.org/wiki/Mars',
+            'otherFacts': {
+              'radius': 3390,
+              'surfacePressure': '0.636 (0.4–0.87) kPa; 0.00628 atm',
+              'equatorialRotationVelocity': '868.22 km/h (241.17 m/s)'
+            },
+            'moons': [
+              {
+                'title': 'Phobos',
+                'discoveredBy': 'Asaph Hall',
+                'discoveryYear': 1800,
+                'planetsName': 'mars',
+                'craters': [
+                  {
+                    'title': 'Stickney',
+                    'diameter': 9
+                  }
+                ]
+              },
+              {
+                'title': 'Deimos',
+                'discoveredBy': 'Asaph Hall',
+                'discoveryYear': 1800,
+                'planetsName': 'mars'
+              }
+            ]
+          }
+        )
+
+        const moons = {}
+        moons[doc.moons[0].title] = doc.moons[0]
+        moons[doc.moons[1].title] = doc.moons[1]
+        phobosId = moons['Phobos'].id
+        stickneyId = moons['Phobos'].craters[0].id
+        done()
+      }
+    )
+  })
+
+  it('should find Phobos and its Stickney crater', function (done) {
+    models.pgmodelTest.moons.findOne(
+      {
+        where: {
+          title: {'equals': 'Phobos'}
+        }
+      },
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'title': 'Phobos',
+            'discoveredBy': 'Asaph Hall',
+            'discoveryYear': 1800,
+            'planetsName': 'mars',
+            'craters': [
+              {
+                'title': 'Stickney',
+                'diameter': 9
+              }
+            ]
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should find Deimos and no craters', function (done) {
+    models.pgmodelTest.moons.findOne(
+      {
+        where: {
+          title: {'equals': 'Deimos'}
+        }
+      },
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'title': 'Deimos',
+            'discoveredBy': 'Asaph Hall',
+            'discoveryYear': 1800,
+            'planetsName': 'mars',
+            'craters': []
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should update Mars with more accurate info', function (done) {
+    models.pgmodelTest.planets.update(
+      {
+        name: 'mars',
+        title: 'Mars',
+        type: 'Terrestrial',
+        diameter: 6779,
+        color: 'red',
+        url: 'http://en.wikipedia.org/wiki/Mars',
+        'otherFacts': {
+          'radius': 3390,
+          'surfacePressure': '0.636 (0.4–0.87) kPa; 0.00628 atm',
+          'equatorialRotationVelocity': '868.22 km/h (241.17 m/s)',
+          'lengthOfDay': '1d 0h 40m'
+        },
+        moons: [
+          {
+            id: phobosId,
+            title: 'Phobos',
+            discoveredBy: 'Asaph Hall',
+            discoveryYear: 1875,
+            craters: [
+              {
+                id: stickneyId,
+                title: 'Stickney',
+                diameter: 10
+              }
+            ]
+          }
+        ]
+      },
+      {},
+      function (err, doc) {
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it('should find updated Mars via primary key', function (done) {
+    models.pgmodelTest.planets.findById(
+      'mars',
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc.moons).to.have.length(1)
+        expect(doc).to.containSubset(
+          {
+            'name': 'mars',
+            'title': 'Mars',
+            'type': 'Terrestrial',
+            'diameter': '6779',
+            'color': 'red',
+            'url': 'http://en.wikipedia.org/wiki/Mars',
+            'otherFacts': {
+              'radius': 3390,
+              'surfacePressure': '0.636 (0.4–0.87) kPa; 0.00628 atm',
+              'equatorialRotationVelocity': '868.22 km/h (241.17 m/s)',
+              'lengthOfDay': '1d 0h 40m'
+            },
+            'moons': [
+              {
+                id: phobosId,
+                'title': 'Phobos',
+                'discoveredBy': 'Asaph Hall',
+                'discoveryYear': 1875,
+                'planetsName': 'mars',
+                'craters': [
+                  {
+                    id: stickneyId,
+                    'title': 'Stickney',
+                    'diameter': 10
+                  }
+                ]
+              }
+            ]
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should find Stickney crater directly', function (done) {
+    models.pgmodelTest.craters.findById(
+      stickneyId,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'diameter': 10,
+            'id': stickneyId,
+            'moonsId': phobosId,
+            'title': 'Stickney'
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should delete Mars, and in-turn Phobos and Stickney', function (done) {
+    models.pgmodelTest.planets.destroyById(
+      'mars',
+      function (err, doc) {
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it('should now fail to find Phobos', function (done) {
+    models.pgmodelTest.moons.findOne(
+      {
+        filter: {
+          where: {
+            title: {'equals': 'Phobos'}
+          }
+        }
+      },
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.equal(undefined)
+        done()
+      }
+    )
+  })
+
+  it('should now fail to find Stickney crater directly', function (done) {
+    models.pgmodelTest.craters.findById(
+      stickneyId,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.equal(undefined)
+        done()
+      }
+    )
+  })
+
+  it('Should finally drop-cascade the pg_model_test schema', function (done) {
+    sqlScriptRunner(
+      [
+        'uninstall.sql'
+      ],
+      client,
+      function (err) {
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+})

--- a/packages/pg-model/test/test-promises.js
+++ b/packages/pg-model/test/test-promises.js
@@ -479,13 +479,7 @@ describe('Test promise API', function () {
   })
 
   it('should delete Maggie/Margaret by via her id', function (done) {
-    models.pgmodelTest.person.destroyById(
-      2,
-      function (err, doc) {
-        expect(err).to.equal(null)
-        done()
-      }
-    )
+    models.pgmodelTest.person.destroyById(2).then(() => done())
   })
 
   it('should fail getting a deleted record', function (done) {
@@ -878,13 +872,8 @@ describe('Test promise API', function () {
   })
 
   it('should delete Mars, and in-turn Phobos and Stickney', function (done) {
-    models.pgmodelTest.planets.destroyById(
-      'mars',
-      function (err, doc) {
-        expect(err).to.equal(null)
-        done()
-      }
-    )
+    models.pgmodelTest.planets.destroyById('mars')
+      .then(() => done())
   })
 
   it('should now fail to find Phobos', function (done) {

--- a/packages/pg-model/test/test-promises.js
+++ b/packages/pg-model/test/test-promises.js
@@ -188,11 +188,9 @@ describe('Test promise API', function () {
     )
   })
 
-  it('should find a person via primary key', function (done) {
-    models.pgmodelTest.person.findById(
-      3,
-      function (err, doc) {
-        expect(err).to.equal(null)
+  it('should find a person via primary key', function () {
+    return models.pgmodelTest.person.findById(3)
+      .then(doc =>
         expect(doc).to.containSubset(
           {
             'employeeNo': '3',
@@ -201,214 +199,184 @@ describe('Test promise API', function () {
             'age': 8
           }
         )
-        done()
-      }
     )
   })
 
-  it("should fail finding a person that's not there", function (done) {
-    models.pgmodelTest.person.findById(
-      6,
-      function (err, doc) {
-        expect(err).to.equal(null)
+  it("should fail finding a person that's not there", function () {
+    return models.pgmodelTest.person.findById(6)
+      .then(doc =>
         expect(doc).to.equal(undefined)
-        done()
-      }
-    )
+      )
   })
 
-  it('should find 5 people, youngest first', function (done) {
-    models.pgmodelTest.person.find(
+  it('should find 5 people, youngest first', async function () {
+    const doc = await models.pgmodelTest.person.find(
       {
         orderBy: ['age']
-      },
-      function (err, doc) {
-        expect(err).to.equal(null)
-
-        expect(doc[0].age).to.equal(8)
-        expect(doc[1].age).to.equal(10)
-        expect(doc[2].age).to.equal(36)
-        expect(doc[3].age).to.equal(39)
-        expect(doc[4].age).to.equal(null)
-        expect(doc).to.containSubset(
-          [
-            {
-              'age': 8,
-              'employeeNo': '3',
-              'firstName': 'Lisa',
-              'lastName': 'Simpson'
-            },
-            {
-              'age': 10,
-              'employeeNo': '5',
-              'firstName': 'Bart',
-              'lastName': 'Simpson'
-            },
-            {
-              'age': 36,
-              'employeeNo': '4',
-              'firstName': 'Marge',
-              'lastName': 'Simpson'
-            },
-            {
-              'age': 39,
-              'employeeNo': '1',
-              'firstName': 'Homer',
-              'lastName': 'Simpson'
-            },
-            {
-              'age': null,
-              'employeeNo': '2',
-              'firstName': 'Maggie',
-              'lastName': 'Simpson'
-            }
-          ]
-        )
-        done()
       }
+    )
+
+    expect(doc[0].age).to.equal(8)
+    expect(doc[1].age).to.equal(10)
+    expect(doc[2].age).to.equal(36)
+    expect(doc[3].age).to.equal(39)
+    expect(doc[4].age).to.equal(null)
+    expect(doc).to.containSubset(
+      [
+        {
+          'age': 8,
+          'employeeNo': '3',
+          'firstName': 'Lisa',
+          'lastName': 'Simpson'
+        },
+        {
+          'age': 10,
+          'employeeNo': '5',
+          'firstName': 'Bart',
+          'lastName': 'Simpson'
+        },
+        {
+          'age': 36,
+          'employeeNo': '4',
+          'firstName': 'Marge',
+          'lastName': 'Simpson'
+        },
+        {
+          'age': 39,
+          'employeeNo': '1',
+          'firstName': 'Homer',
+          'lastName': 'Simpson'
+        },
+        {
+          'age': null,
+          'employeeNo': '2',
+          'firstName': 'Maggie',
+          'lastName': 'Simpson'
+        }
+      ]
     )
   })
 
-  it('should find 3 people, eldest first', function (done) {
-    models.pgmodelTest.person.find(
+  it('should find 3 people, eldest first', async function () {
+    const doc = await models.pgmodelTest.person.find(
       {
         orderBy: ['-age'],
         nullsLast: true
-      },
-      function (err, doc) {
-        expect(err).to.equal(null)
-        expect(doc[0].age).to.equal(39)
-        expect(doc[1].age).to.equal(36)
-        expect(doc[2].age).to.equal(10)
-        expect(doc[3].age).to.equal(8)
-        expect(doc[4].age).to.equal(null)
-        done()
       }
     )
+
+    expect(doc).to.have.length(5)
+    expect(doc[0].age).to.equal(39)
+    expect(doc[1].age).to.equal(36)
+    expect(doc[2].age).to.equal(10)
+    expect(doc[3].age).to.equal(8)
+    expect(doc[4].age).to.equal(null)
   })
 
-  it('should find Bart by name', function (done) {
-    models.pgmodelTest.person.find(
+  it('should find Bart by name', async () => {
+    const doc = await models.pgmodelTest.person.find(
       {
         where: {
           firstName: {equals: 'Bart'},
           lastName: {equals: 'Simpson'}
         }
-      },
-      function (err, doc) {
-        expect(err).to.equal(null)
-        expect(doc).to.have.length(1)
-        expect(doc).to.containSubset(
-          [
-            {
-              'age': 10,
-              'employeeNo': '5',
-              'firstName': 'Bart',
-              'lastName': 'Simpson'
-            }
-          ]
-        )
-
-        done()
       }
+    )
+
+    expect(doc).to.have.length(1)
+    expect(doc).to.containSubset(
+      [
+        {
+          'age': 10,
+          'employeeNo': '5',
+          'firstName': 'Bart',
+          'lastName': 'Simpson'
+        }
+      ]
     )
   })
 
-  it('should find Bart and Lisa (eldest with limit 2/offset 2)', function (done) {
-    models.pgmodelTest.person.find(
+  it('should find Bart and Lisa (eldest with limit 2/offset 2)', async () => {
+    const doc = await models.pgmodelTest.person.find(
       {
         orderBy: ['-age'],
         nullsLast: true,
         limit: 2,
         offset: 2
-      },
-      function (err, doc) {
-        expect(err).to.equal(null)
-        expect(doc).to.have.length(2)
-        expect(doc[0].employeeNo).to.eql('5')
-        expect(doc[1].employeeNo).to.eql('3')
-        expect(doc).to.containSubset(
-          [
-            {
-              'age': 10,
-              'employeeNo': '5',
-              'firstName': 'Bart',
-              'lastName': 'Simpson'
-            },
-            {
-              'age': 8,
-              'employeeNo': '3',
-              'firstName': 'Lisa',
-              'lastName': 'Simpson'
-            }
-          ]
-        )
-        done()
       }
+    )
+
+    expect(doc).to.have.length(2)
+    expect(doc[0].employeeNo).to.eql('5')
+    expect(doc[1].employeeNo).to.eql('3')
+    expect(doc).to.containSubset(
+      [
+        {
+          'age': 10,
+          'employeeNo': '5',
+          'firstName': 'Bart',
+          'lastName': 'Simpson'
+        },
+        {
+          'age': 8,
+          'employeeNo': '3',
+          'firstName': 'Lisa',
+          'lastName': 'Simpson'
+        }
+      ]
     )
   })
 
-  it('should get the second youngest known person (Marge)', function (done) {
-    models.pgmodelTest.person.findOne(
+  it('should get the second youngest known person (Marge)', async () => {
+    const doc = await models.pgmodelTest.person.findOne(
       {
         orderBy: ['age'],
         nullsLast: true,
         offset: 1
-      },
-      function (err, doc) {
-        expect(err).to.equal(null)
-        expect(doc).to.containSubset(
-          {
-            'age': 10,
-            'employeeNo': '5',
-            'firstName': 'Bart',
-            'lastName': 'Simpson'
-          }
-        )
+      }
+    )
 
-        done()
+    expect(doc).to.containSubset(
+      {
+        'age': 10,
+        'employeeNo': '5',
+        'firstName': 'Bart',
+        'lastName': 'Simpson'
       }
     )
   })
 
-  it('should get one Homer by name', function (done) {
-    models.pgmodelTest.person.findOne(
+  it('should get one Homer by name', function () {
+    return models.pgmodelTest.person.findOne(
       {
         where: {
           firstName: {equals: 'Homer'},
           lastName: {equals: 'Simpson'}
         }
-      },
-      function (err, doc) {
-        expect(err).to.equal(null)
-        expect(doc).to.containSubset(
-          {
-            'age': 39,
-            'employeeNo': '1',
-            'firstName': 'Homer',
-            'lastName': 'Simpson'
-          }
-        )
-
-        done()
       }
+    ).then(doc =>
+      expect(doc).to.containSubset(
+        {
+          'age': 39,
+          'employeeNo': '1',
+          'firstName': 'Homer',
+          'lastName': 'Simpson'
+        }
+      )
     )
   })
 
-  it("shouldn't get one missing person", function (done) {
-    models.pgmodelTest.person.findOne(
+  it("shouldn't get one missing person", async () => {
+    const doc = await models.pgmodelTest.person.findOne(
       {
         where: {
           firstName: {equals: 'Ned'},
           lastName: {equals: 'Flanders'}
         }
-      },
-      function (err, doc) {
-        expect(err).to.equal(null)
-        expect(doc).to.equal(undefined)
-        done()
       }
     )
+
+    expect(doc).to.equal(undefined)
   })
 
   it("should update Maggie's age to 1", function (done) {

--- a/packages/pg-model/test/test-promises.js
+++ b/packages/pg-model/test/test-promises.js
@@ -379,27 +379,21 @@ describe('Test promise API', function () {
     expect(doc).to.equal(undefined)
   })
 
-  it("should update Maggie's age to 1", function (done) {
-    models.pgmodelTest.person.update(
+  it("should update Maggie's age to 1", () => {
+    return models.pgmodelTest.person.update(
       {
         employeeNo: 2,
         age: 1,
         firstName: 'Maggie',
         lastName: 'Simpson'
       },
-      {},
-      function (err) {
-        expect(err).to.equal(null)
-        done()
-      }
+      {}
     )
   })
 
-  it('should find Maggie has an age now', function (done) {
-    models.pgmodelTest.person.findById(
-      2,
-      function (err, doc) {
-        expect(err).to.equal(null)
+  it('should find Maggie has an age now', () => {
+    models.pgmodelTest.person.findById(2)
+      .then(doc =>
         expect(doc).to.containSubset(
           {
             'employeeNo': '2',
@@ -408,25 +402,20 @@ describe('Test promise API', function () {
             'age': 1
           }
         )
-        done()
-      }
-    )
+      )
   })
 
-  it('should update Maggie again, but this time without an age', function (done) {
-    models.pgmodelTest.person.update(
+  it('should update Maggie again, but this time without an age', async () => {
+    await models.pgmodelTest.person.update(
       {
         employeeNo: 2,
         firstName: 'Maggie',
         lastName: 'Simpson'
       },
-      {},
-      function (err, doc) {
-        expect(err).to.equal(null)
-        done()
-      }
+      {}
     )
   })
+
 
   it("should find Maggie's age has gone again", function (done) {
     models.pgmodelTest.person.findById(
@@ -452,12 +441,8 @@ describe('Test promise API', function () {
         employeeNo: 2,
         firstName: 'Margaret'
       },
-      {},
-      function (err, doc) {
-        expect(err).to.equal(null)
-        done()
-      }
-    )
+      {}
+    ).then(() => done())
   })
 
   it('should find Maggie is now a Margaret', function (done) {

--- a/packages/pg-model/test/test-promises.js
+++ b/packages/pg-model/test/test-promises.js
@@ -499,7 +499,7 @@ describe('Test promise API', function () {
     )
   })
 
-  it('should upsert (insert) Grampa', function (done) {
+  it('should upsert (insert) Grampa', () => {
     models.pgmodelTest.person.upsert(
       {
         employeeNo: 10,
@@ -507,18 +507,15 @@ describe('Test promise API', function () {
         lastName: 'Simpson',
         age: 82
       },
-      {},
-      function (err, idProperties) {
-        expect(idProperties).to.eql(
-          {
-            idProperties: {
-              employeeNo: '10'
-            }
+      {}
+    ).then(idProperties =>
+      expect(idProperties).to.eql(
+        {
+          idProperties: {
+            employeeNo: '10'
           }
-        )
-        expect(err).to.equal(null)
-        done()
-      }
+        }
+      )
     )
   })
 
@@ -548,12 +545,8 @@ describe('Test promise API', function () {
         lastName: 'Simpson',
         age: 83
       },
-      {},
-      function (err, doc) {
-        expect(err).to.equal(null)
-        done()
-      }
-    )
+      {}
+    ).then(() => done())
   })
 
   it('should find Grampa has now been updates via upsert', function (done) {
@@ -583,12 +576,8 @@ describe('Test promise API', function () {
       },
       {
         setMissingPropertiesToNull: false
-      },
-      function (err, doc) {
-        expect(err).to.equal(null)
-        done()
       }
-    )
+    ).then(() => done())
   })
 
   it('should find Grampa again, with his age preserved and an updated name', function (done) {
@@ -616,12 +605,8 @@ describe('Test promise API', function () {
         firstName: 'Abraham',
         lastName: 'Simpson'
       },
-      {},
-      function (err, doc) {
-        expect(err).to.equal(null)
-        done()
-      }
-    )
+      {}
+    ).then(() => done())
   })
 
   it('should find Grampa again, but now with a null age', function (done) {

--- a/packages/pg-model/test/test-promises.js
+++ b/packages/pg-model/test/test-promises.js
@@ -139,18 +139,18 @@ describe('Test promise API', function () {
     )
       .then(() => assert(false))
       .catch(err => {
-          expect(err).to.containSubset(
-            {
-              'code': '23505',
-              'constraint': 'person_pkey',
-              'detail': 'Key (employee_no)=(1) already exists.',
-              'name': 'error',
-              'schema': 'pgmodel_test',
-              'severity': 'ERROR',
-              'table': 'person'
-            }
+        expect(err).to.containSubset(
+          {
+            'code': '23505',
+            'constraint': 'person_pkey',
+            'detail': 'Key (employee_no)=(1) already exists.',
+            'name': 'error',
+            'schema': 'pgmodel_test',
+            'severity': 'ERROR',
+            'table': 'person'
+          }
           )
-        }
+      }
       )
   })
 
@@ -415,7 +415,6 @@ describe('Test promise API', function () {
       {}
     )
   })
-
 
   it("should find Maggie's age has gone again", function (done) {
     models.pgmodelTest.person.findById(

--- a/packages/pg-model/test/test.js
+++ b/packages/pg-model/test/test.js
@@ -479,12 +479,8 @@ describe('Run some basic tests', function () {
         employeeNo: 2,
         firstName: 'Margaret'
       },
-      {},
-      function (err, doc) {
-        expect(err).to.equal(null)
-        done()
-      }
-    )
+      {}
+    ).then(() => done())
   })
 
   it('should find Maggie is now a Margaret', function (done) {

--- a/packages/pg-model/test/test.js
+++ b/packages/pg-model/test/test.js
@@ -418,21 +418,27 @@ describe('Run some basic tests', function () {
     )
   })
 
-  it("should update Maggie's age to 1", () => {
-    return models.pgmodelTest.person.update(
+  it("should update Maggie's age to 1", function (done) {
+    models.pgmodelTest.person.update(
       {
         employeeNo: 2,
         age: 1,
         firstName: 'Maggie',
         lastName: 'Simpson'
       },
-      {}
+      {},
+      function (err) {
+        expect(err).to.equal(null)
+        done()
+      }
     )
   })
 
-  it('should find Maggie has an age now', () => {
-    models.pgmodelTest.person.findById(2)
-      .then(doc =>
+  it('should find Maggie has an age now', function (done) {
+    models.pgmodelTest.person.findById(
+      2,
+      function (err, doc) {
+        expect(err).to.equal(null)
         expect(doc).to.containSubset(
           {
             'employeeNo': '2',
@@ -441,17 +447,23 @@ describe('Run some basic tests', function () {
             'age': 1
           }
         )
-      )
+        done()
+      }
+    )
   })
 
-  it('should update Maggie again, but this time without an age', async () => {
-    await models.pgmodelTest.person.update(
+  it('should update Maggie again, but this time without an age', function (done) {
+    models.pgmodelTest.person.update(
       {
         employeeNo: 2,
         firstName: 'Maggie',
         lastName: 'Simpson'
       },
-      {}
+      {},
+      function (err, doc) {
+        expect(err).to.equal(null)
+        done()
+      }
     )
   })
 
@@ -479,8 +491,12 @@ describe('Run some basic tests', function () {
         employeeNo: 2,
         firstName: 'Margaret'
       },
-      {}
-    ).then(() => done())
+      {},
+      function (err, doc) {
+        expect(err).to.equal(null)
+        done()
+      }
+    )
   })
 
   it('should find Maggie is now a Margaret', function (done) {

--- a/packages/pg-model/test/test.js
+++ b/packages/pg-model/test/test.js
@@ -14,6 +14,7 @@ const chai = require('chai')
 const chaiSubset = require('chai-subset')
 chai.use(chaiSubset)
 const expect = chai.expect
+const assert = require('assert')
 
 describe('Run some basic tests', function () {
   let client
@@ -417,27 +418,21 @@ describe('Run some basic tests', function () {
     )
   })
 
-  it("should update Maggie's age to 1", function (done) {
-    models.pgmodelTest.person.update(
+  it("should update Maggie's age to 1", () => {
+    return models.pgmodelTest.person.update(
       {
         employeeNo: 2,
         age: 1,
         firstName: 'Maggie',
         lastName: 'Simpson'
       },
-      {},
-      function (err) {
-        expect(err).to.equal(null)
-        done()
-      }
+      {}
     )
   })
 
-  it('should find Maggie has an age now', function (done) {
-    models.pgmodelTest.person.findById(
-      2,
-      function (err, doc) {
-        expect(err).to.equal(null)
+  it('should find Maggie has an age now', () => {
+    models.pgmodelTest.person.findById(2)
+      .then(doc =>
         expect(doc).to.containSubset(
           {
             'employeeNo': '2',
@@ -446,23 +441,17 @@ describe('Run some basic tests', function () {
             'age': 1
           }
         )
-        done()
-      }
-    )
+      )
   })
 
-  it('should update Maggie again, but this time without an age', function (done) {
-    models.pgmodelTest.person.update(
+  it('should update Maggie again, but this time without an age', async () => {
+    await models.pgmodelTest.person.update(
       {
         employeeNo: 2,
         firstName: 'Maggie',
         lastName: 'Simpson'
       },
-      {},
-      function (err, doc) {
-        expect(err).to.equal(null)
-        done()
-      }
+      {}
     )
   })
 

--- a/packages/pg-model/test/test.js
+++ b/packages/pg-model/test/test.js
@@ -14,7 +14,6 @@ const chai = require('chai')
 const chaiSubset = require('chai-subset')
 chai.use(chaiSubset)
 const expect = chai.expect
-const assert = require('assert')
 
 describe('Run some basic tests', function () {
   let client

--- a/packages/tymly/lib/plugin/components/services/storage/Memory-model.js
+++ b/packages/tymly/lib/plugin/components/services/storage/Memory-model.js
@@ -8,7 +8,7 @@ require('underscore-query')(_)
 
 const NotSet = 'NetSet'
 
-function promised(obj, fn, ...args) {
+function promised (obj, fn, ...args) {
   return new Promise((resolve, reject) => {
     fn.call(obj, ...args, (err, result) => {
       if (err) {

--- a/packages/tymly/lib/plugin/components/services/storage/Memory-model.js
+++ b/packages/tymly/lib/plugin/components/services/storage/Memory-model.js
@@ -6,6 +6,20 @@ const _ = require('lodash')
 
 require('underscore-query')(_)
 
+const NotSet = 'NetSet'
+
+function promised(obj, fn, ...args) {
+  return new Promise((resolve, reject) => {
+    fn.call(obj, ...args, (err, result) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(result)
+      }
+    })
+  })
+} // promised
+
 // TODO: This could be a useful module in its own right?
 
 class MemoryModel {
@@ -23,6 +37,8 @@ class MemoryModel {
     } else {
       this.primaryKey = ['id']
     }
+
+    this.promised = (...args) => promised(this, ...args)
   }
 
   extractIdPropertiesFromDoc (doc) {
@@ -36,7 +52,11 @@ class MemoryModel {
     return properties
   }
 
-  create (jsonData, options, callback) {
+  create (jsonData, options, callback = NotSet) {
+    if (callback === NotSet) {
+      return this.promised(this.create, jsonData, options)
+    }
+
     const _this = this
     let idProperties
     let err = null
@@ -140,7 +160,10 @@ class MemoryModel {
   }
 
   // TODO: Options! limit/offset etc.
-  find (options, callback) {
+  find (options, callback = NotSet) {
+    if (callback === NotSet) {
+      return this.promised(this.find, options)
+    }
     const output = this.applyWhere(options)
     callback(null, output)
   }
@@ -169,7 +192,10 @@ class MemoryModel {
     return properties
   }
 
-  findById (id, callback) {
+  findById (id, callback = NotSet) {
+    if (callback === NotSet) {
+      return this.promised(this.findById, id)
+    }
     if (!_.isArray(id)) {
       id = [id]
     }
@@ -182,7 +208,11 @@ class MemoryModel {
     )
   }
 
-  findOne (options, callback) {
+  findOne (options, callback = NotSet) {
+    if (callback === NotSet) {
+      return this.promised(this.findOne, options)
+    }
+
     let doc
     const output = this.applyWhere(options)
     if (output.length > 0) {
@@ -221,7 +251,11 @@ class MemoryModel {
     return index
   }
 
-  update (doc, options, callback) {
+  update (doc, options, callback = NotSet) {
+    if (callback === NotSet) {
+      return this.promised(this.update, doc, options)
+    }
+
     if (options.setMissingPropertiesToNull === false) {
       return this.patch(doc, options, callback)
     }
@@ -234,7 +268,11 @@ class MemoryModel {
     callback(null)
   }
 
-  patch (doc, options, callback) {
+  patch (doc, options, callback = NotSet) {
+    if (callback === NotSet) {
+      return this.promised(this.patch, doc, options)
+    }
+
     const where = this.extractIdPropertiesFromDoc(doc)
     const index = this.findFirstIndex(where)
     if (index !== -1) {
@@ -243,7 +281,11 @@ class MemoryModel {
     callback(null)
   }
 
-  upsert (doc, options, callback) {
+  upsert (doc, options, callback = NotSet) {
+    if (callback === NotSet) {
+      return this.promised(this.upsert, doc, options)
+    }
+
     const whereProperties = this.extractIdPropertiesFromDoc(doc)
     const index = this.findFirstIndex(whereProperties)
 
@@ -263,7 +305,11 @@ class MemoryModel {
     }
   }
 
-  destroyById (id, callback) {
+  destroyById (id, callback = NotSet) {
+    if (callback === NotSet) {
+      return this.promised(this.destroyById, id)
+    }
+
     if (!_.isArray(id)) {
       id = [id]
     }

--- a/packages/tymly/lib/plugin/components/services/storage/Memory-model.js
+++ b/packages/tymly/lib/plugin/components/services/storage/Memory-model.js
@@ -222,6 +222,10 @@ class MemoryModel {
   }
 
   update (doc, options, callback) {
+    if (options.setMissingPropertiesToNull === false) {
+      return this.patch(doc, options, callback)
+    }
+
     const where = this.extractIdPropertiesFromDoc(doc)
     const index = this.findFirstIndex(where)
     if (index !== -1) {
@@ -231,14 +235,12 @@ class MemoryModel {
   }
 
   patch (doc, options, callback) {
-//    var matches = _.query(this.data, where)
-//    if (matches.length === 1) {
-//      var doc = JSON.parse(JSON.stringify(matches[0]))
-//      doc = this.applySelect(doc, select)
-//      callback(null, doc)
-//    } else {
-//      callback(null, null)
-//    }
+    const where = this.extractIdPropertiesFromDoc(doc)
+    const index = this.findFirstIndex(where)
+    if (index !== -1) {
+      for (const [k, v] of Object.entries(doc)) { this.data[index][k] = v }
+    }
+    callback(null)
   }
 
   upsert (doc, options, callback) {
@@ -246,6 +248,10 @@ class MemoryModel {
     const index = this.findFirstIndex(whereProperties)
 
     if (index !== -1) {
+      if (options.setMissingPropertiesToNull === false) {
+        return this.patch(doc, options, callback)
+      }
+
       this.data[index] = _.cloneDeep(doc)
       callback(null)
     } else {

--- a/packages/tymly/lib/plugin/components/state-resources/upserting/index.js
+++ b/packages/tymly/lib/plugin/components/state-resources/upserting/index.js
@@ -16,12 +16,7 @@ module.exports = class Upserting {
 
   run (doc, context) {
     if (!doc) {
-      context.sendTaskFailure(
-        {
-          error: 'NO_DOC_TO_UPSERT',
-          cause: 'Unable to save document - no document supplied'
-        }
-      )
+      failed(context, 'NO_DOC_TO_UPSERT', 'Unable to save document - no document supplied')
     }
 
     const docToPersist = _.cloneDeep(doc)
@@ -30,13 +25,13 @@ module.exports = class Upserting {
 
     this.model.upsert(docToPersist, {})
       .then(() => context.sendTaskSuccess())
-      .catch(err =>
-          context.sendTaskFailure(
-            {
-              error: 'FAILED_TO_UPSERT',
-              cause: JSON.stringify(err)
-            }
-          )
-      )
+      .catch(err => failed(context, 'FAILED_TO_UPSERT', JSON.stringify(err)))
   } // run
+}
+
+function failed (context, error, cause) {
+  context.sendTaskFailure({
+    error: error,
+    cause: cause
+  })
 }

--- a/packages/tymly/lib/plugin/components/state-resources/upserting/index.js
+++ b/packages/tymly/lib/plugin/components/state-resources/upserting/index.js
@@ -12,31 +12,10 @@ module.exports = class Upserting {
     } else {
       callback(boom.notFound("Unable to initialize Persisting state... unknown model '" + this.modelId + "'", {modelId: this.modelId}))
     }
-  }
+  } // init
 
   run (doc, context) {
-    if (doc) {
-      const docToPersist = _.cloneDeep(doc)
-      docToPersist._executionName = context.executionName
-      // docToPersist.createdBy = tymly.createdBy // TODO: Possibly not the current userId though?
-
-      this.model.upsert(
-        docToPersist,
-        {},
-        function (err, idProperties) {
-          if (err) {
-            context.sendTaskFailure(
-              {
-                error: 'FAILED_TO_UPSERT',
-                cause: JSON.stringify(err)
-              }
-            )
-          } else {
-            context.sendTaskSuccess()
-          }
-        }
-      )
-    } else {
+    if (!doc) {
       context.sendTaskFailure(
         {
           error: 'NO_DOC_TO_UPSERT',
@@ -44,5 +23,20 @@ module.exports = class Upserting {
         }
       )
     }
-  }
+
+    const docToPersist = _.cloneDeep(doc)
+    docToPersist._executionName = context.executionName
+    // docToPersist.createdBy = tymly.createdBy // TODO: Possibly not the current userId though?
+
+    this.model.upsert(docToPersist, {})
+      .then(() => context.sendTaskSuccess())
+      .catch(err =>
+          context.sendTaskFailure(
+            {
+              error: 'FAILED_TO_UPSERT',
+              cause: JSON.stringify(err)
+            }
+          )
+      )
+  } // run
 }

--- a/packages/tymly/test/memory-model-promise-spec.js
+++ b/packages/tymly/test/memory-model-promise-spec.js
@@ -1,0 +1,550 @@
+/* eslint-env mocha */
+
+'use strict'
+const chai = require('chai')
+const chaiSubset = require('chai-subset')
+chai.use(chaiSubset)
+const expect = chai.expect
+const MemoryModel = require('../lib/plugin/components/services/storage/Memory-model')
+
+describe('Memory Model promise tests', function () {
+  let planetsModel
+  let personModel
+  let phobosId
+  let stickneyId
+
+  it('should get some model instances', function () {
+    planetsModel = new MemoryModel(
+      {
+        'id': 'planets',
+        'name': 'planets',
+        'namespace': 'test',
+        'primaryKey': ['name'],
+        'properties': {
+          'name': 'string'
+        }
+      }
+    )
+    personModel = new MemoryModel(
+      {
+        'id': 'people',
+        'name': 'people',
+        'namespace': 'test',
+        'primaryKey': ['employeeNo'],
+        'properties': {
+          'employeeNo': 'number'
+        }
+      }
+    )
+  })
+
+  it('should create a new person', function () {
+    return personModel.create(
+      {
+        employeeNo: 1,
+        firstName: 'Homer',
+        lastName: 'Simpson',
+        age: 39
+      },
+      {}
+    ).then(idProperties =>
+      expect(idProperties).to.eql(
+        {
+          idProperties:
+          {
+            employeeNo: 1
+          }
+        }
+      )
+    )
+  })
+
+  it('should create multiple new people', function () {
+    return personModel.create(
+      [
+        {
+          employeeNo: 2,
+          firstName: 'Maggie',
+          lastName: 'Simpson'
+        },
+        {
+          employeeNo: 3,
+          firstName: 'Lisa',
+          lastName: 'Simpson',
+          age: 8
+        },
+        {
+          employeeNo: 4,
+          firstName: 'Marge',
+          lastName: 'Simpson',
+          age: 36
+        },
+        {
+          employeeNo: 5,
+          firstName: 'Bart',
+          lastName: 'Simpson',
+          age: 10
+        }
+      ]
+    )
+  })
+
+  it('should fail creating a new person with an already-used primary key', function () {
+    return personModel.create(
+      {
+        employeeNo: 1,
+        firstName: 'Ned',
+        lastName: 'Flanders',
+        age: 60
+      },
+      {}
+    )
+      .then(() => assert(false))
+      .catch(err => {
+          expect(err).to.containSubset(
+            {
+              'name': 'DuplicatePrimaryKey'
+            }
+          )
+        }
+      )
+  })
+
+  it('should fail creating new people with an already-used primary key', function () {
+    return personModel.create(
+      [
+        {
+          employeeNo: 2,
+          firstName: 'Maude',
+          lastName: 'Flanders'
+        }
+      ],
+      {}
+    )
+      .then(() => assert(false))
+      .catch(err => {
+        expect(err).to.containSubset(
+          {
+            'name': 'DuplicatePrimaryKey'
+          }
+        )
+      }
+    )
+  })
+
+  it('should find a person via primary key', function () {
+    return personModel.findById(3)
+      .then(doc =>
+        expect(doc).to.containSubset(
+          {
+            'employeeNo': 3,
+            'firstName': 'Lisa',
+            'lastName': 'Simpson',
+            'age': 8
+          }
+        )
+    )
+  })
+
+  it("should fail finding a person that's not there", function () {
+    return personModel.findById(6)
+      .then(doc =>
+        expect(doc).to.equal(undefined)
+      )
+  })
+
+  it('should find 5 people, youngest first', async function () {
+    const doc = await personModel.find(
+      {
+        orderBy: ['age']
+      }
+    )
+
+    expect(doc).to.containSubset(
+      [
+        {
+          'age': 8,
+          'employeeNo': 3,
+          'firstName': 'Lisa',
+          'lastName': 'Simpson'
+        },
+        {
+          'age': 10,
+          'employeeNo': 5,
+          'firstName': 'Bart',
+          'lastName': 'Simpson'
+        },
+        {
+          'age': 36,
+          'employeeNo': 4,
+          'firstName': 'Marge',
+          'lastName': 'Simpson'
+        },
+        {
+          'age': 39,
+          'employeeNo': 1,
+          'firstName': 'Homer',
+          'lastName': 'Simpson'
+        },
+        {
+          'employeeNo': 2,
+          'firstName': 'Maggie',
+          'lastName': 'Simpson'
+        }
+      ]
+    )
+  })
+
+
+  it('should find Bart by name', async () => {
+    const doc = await personModel.find(
+      {
+        where: {
+          firstName: {equals: 'Bart'},
+          lastName: {equals: 'Simpson'}
+        }
+      }
+    )
+
+    expect(doc).to.have.length(1)
+    expect(doc).to.containSubset(
+      [
+        {
+          'age': 10,
+          'employeeNo': 5,
+          'firstName': 'Bart',
+          'lastName': 'Simpson'
+        }
+      ]
+    )
+  })
+
+  it('should get one Homer by name', function () {
+    return personModel.findOne(
+      {
+        where: {
+          firstName: {equals: 'Homer'},
+          lastName: {equals: 'Simpson'}
+        }
+      }
+    ).then(doc =>
+      expect(doc).to.containSubset(
+        {
+          'age': 39,
+          'employeeNo': 1,
+          'firstName': 'Homer',
+          'lastName': 'Simpson'
+        }
+      )
+    )
+  })
+
+  it("shouldn't get one missing person", async () => {
+    const doc = await personModel.findOne(
+      {
+        where: {
+          firstName: {equals: 'Ned'},
+          lastName: {equals: 'Flanders'}
+        }
+      }
+    )
+
+    expect(doc).to.equal(undefined)
+  })
+
+  it("should update Maggie's age to 1", () => {
+    return personModel.update(
+      {
+        employeeNo: 2,
+        age: 1,
+        firstName: 'Maggie',
+        lastName: 'Simpson'
+      },
+      {}
+    )
+  })
+
+  it('should find Maggie has an age now', () => {
+    personModel.findById(2)
+      .then(doc =>
+        expect(doc).to.containSubset(
+          {
+            'employeeNo': 2,
+            'firstName': 'Maggie',
+            'lastName': 'Simpson',
+            'age': 1
+          }
+        )
+      )
+  })
+
+  it('should update Maggie again, but this time without an age', async () => {
+    await personModel.update(
+      {
+        employeeNo: 2,
+        firstName: 'Maggie',
+        lastName: 'Simpson'
+      },
+      {}
+    )
+  })
+
+
+  it("should find Maggie's age has gone again", async () => {
+    const doc = await personModel.findById(2)
+
+    expect(doc).to.containSubset(
+      {
+        'employeeNo': 2,
+        'firstName': 'Maggie',
+        'lastName': 'Simpson'
+      }
+    )
+  })
+
+  it('should patch Maggie to Margaret', function (done) {
+    personModel.patch(
+      {
+        employeeNo: 2,
+        firstName: 'Margaret'
+      },
+      {}
+    ).then(() => done())
+  })
+
+  it('should find Maggie is now a Margaret', async () =>  {
+    const doc = await personModel.findById(2)
+
+    expect(doc).to.containSubset(
+      {
+        'employeeNo': 2,
+        'firstName': 'Margaret',
+        'lastName': 'Simpson'
+      }
+    )
+  })
+
+  it('should delete Maggie/Margaret by via her id', function (done) {
+    personModel.destroyById(2).then(() => done())
+  })
+
+  it('should fail getting a deleted record', async () => {
+    const doc = await personModel.findById(2)
+    expect(doc).to.equal(undefined)
+  })
+
+  it('should upsert (insert) Grampa', () => {
+    personModel.upsert(
+      {
+        employeeNo: 10,
+        firstName: 'Abe',
+        lastName: 'Simpson',
+        age: 82
+      },
+      {}
+    ).then(idProperties =>
+      expect(idProperties).to.eql(
+        {
+          idProperties: {
+            employeeNo: 10
+          }
+        }
+      )
+    )
+  })
+
+  it('should find Grampa has been inserted via upsert', async () => {
+    const doc = await personModel.findById(10)
+    expect(doc).to.containSubset(
+      {
+        'employeeNo': 10,
+        'firstName': 'Abe',
+        'lastName': 'Simpson',
+        'age': 82
+      }
+    )
+  })
+
+  it('should upsert (update) Grampa', function (done) {
+    personModel.upsert(
+      {
+        employeeNo: 10,
+        firstName: 'Abraham',
+        lastName: 'Simpson',
+        age: 82
+      },
+      {}
+    ).then(() => done())
+  })
+
+  it('should find Grampa has now been updates via upsert', async () => {
+    const doc = await personModel.findById(10)
+    expect(doc).to.containSubset(
+      {
+        'employeeNo': 10,
+        'firstName': 'Abraham',
+        'lastName': 'Simpson',
+        'age': 82
+      }
+    )
+  })
+
+  it('should now upsert (update) Grampa, resetting his name', (done) => {
+    personModel.upsert(
+      {
+        employeeNo: 10,
+        firstName: 'Abe',
+        lastName: 'Simpson'
+      },
+      {
+        setMissingPropertiesToNull: false
+      }
+    ).then(() => done())
+  })
+
+  it('should find Grampa again, with his age preserved and an updated name', async () => {
+    const doc = await personModel.findById(10)
+    expect(doc).to.containSubset(
+      {
+        'employeeNo': 10,
+        'firstName': 'Abe',
+        'lastName': 'Simpson',
+        'age': 82
+      }
+    )
+
+  })
+
+  it('should upsert (update) Grampa again, but turn age to null', function (done) {
+    personModel.upsert(
+      {
+        employeeNo: 10,
+        firstName: 'Abraham',
+        lastName: 'Simpson'
+      },
+      {}
+    ).then(() => done())
+  })
+
+  it('should find Grampa again, but now with a null age', async () => {
+    const doc = await personModel.findById(10)
+    expect(doc).to.containSubset(
+      {
+        'employeeNo': 10,
+        'firstName': 'Abraham',
+        'lastName': 'Simpson'
+      }
+    )
+
+  })
+
+  it('should create mars, with two moons and a few craters', function (done) {
+    planetsModel.create(
+      {
+        name: 'mars',
+        title: 'Mars',
+        type: 'Terrestrial',
+        diameter: 6700,
+        color: 'red',
+        url: 'http://en.wikipedia.org/wiki/Mars',
+        otherFacts: {
+          radius: 3390,
+          surfacePressure: '0.636 (0.4–0.87) kPa; 0.00628 atm',
+          equatorialRotationVelocity: '868.22 km/h (241.17 m/s)'
+        },
+        moons: [
+          {
+            title: 'Phobos',
+            discoveredBy: 'Asaph Hall',
+            discoveryYear: 1800,
+            craters: [
+              {
+                title: 'Stickney',
+                diameter: 9
+              }
+            ]
+          },
+          {
+            title: 'Deimos',
+            discoveredBy: 'Asaph Hall',
+            discoveryYear: 1800
+          }
+        ]
+      },
+      {},
+      function (err, idProperties) {
+        expect(err).to.equal(null)
+        expect(idProperties).to.eql(
+          {
+            idProperties: {
+              name: 'mars'
+            }
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should find Mars via primary key', function (done) {
+    planetsModel.findById(
+      'mars',
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'name': 'mars',
+            'title': 'Mars',
+            'type': 'Terrestrial',
+            'diameter': 6700,
+            'color': 'red',
+            'url': 'http://en.wikipedia.org/wiki/Mars',
+            'otherFacts': {
+              'radius': 3390,
+              'surfacePressure': '0.636 (0.4–0.87) kPa; 0.00628 atm',
+              'equatorialRotationVelocity': '868.22 km/h (241.17 m/s)'
+            },
+            'moons': [
+              {
+                'title': 'Phobos',
+                'discoveredBy': 'Asaph Hall',
+                'discoveryYear': 1800,
+                'craters': [
+                  {
+                    'title': 'Stickney',
+                    'diameter': 9
+                  }
+                ]
+              },
+              {
+                'title': 'Deimos',
+                'discoveredBy': 'Asaph Hall',
+                'discoveryYear': 1800
+              }
+            ]
+          }
+        )
+
+        const moons = {}
+        moons[doc.moons[0].title] = doc.moons[0]
+        moons[doc.moons[1].title] = doc.moons[1]
+        phobosId = moons['Phobos'].id
+        stickneyId = moons['Phobos'].craters[0].id
+        done()
+      }
+    )
+  })
+
+
+  it('should delete Mars', function (done) {
+    planetsModel.destroyById('mars')
+      .then(() => done())
+  })
+
+  it('should now fail to find Mars', () => {
+    return planetsModel.findById('mars')
+      .then(doc => expect(doc).to.equal(undefined))
+  })
+
+
+})

--- a/packages/tymly/test/memory-model-promise-spec.js
+++ b/packages/tymly/test/memory-model-promise-spec.js
@@ -6,12 +6,11 @@ const chaiSubset = require('chai-subset')
 chai.use(chaiSubset)
 const expect = chai.expect
 const MemoryModel = require('../lib/plugin/components/services/storage/Memory-model')
+const assert = require('assert')
 
 describe('Memory Model promise tests', function () {
   let planetsModel
   let personModel
-  let phobosId
-  let stickneyId
 
   it('should get some model instances', function () {
     planetsModel = new MemoryModel(
@@ -101,12 +100,12 @@ describe('Memory Model promise tests', function () {
     )
       .then(() => assert(false))
       .catch(err => {
-          expect(err).to.containSubset(
-            {
-              'name': 'DuplicatePrimaryKey'
-            }
+        expect(err).to.containSubset(
+          {
+            'name': 'DuplicatePrimaryKey'
+          }
           )
-        }
+      }
       )
   })
 
@@ -194,7 +193,6 @@ describe('Memory Model promise tests', function () {
       ]
     )
   })
-
 
   it('should find Bart by name', async () => {
     const doc = await personModel.find(
@@ -289,7 +287,6 @@ describe('Memory Model promise tests', function () {
     )
   })
 
-
   it("should find Maggie's age has gone again", async () => {
     const doc = await personModel.findById(2)
 
@@ -312,7 +309,7 @@ describe('Memory Model promise tests', function () {
     ).then(() => done())
   })
 
-  it('should find Maggie is now a Margaret', async () =>  {
+  it('should find Maggie is now a Margaret', async () => {
     const doc = await personModel.findById(2)
 
     expect(doc).to.containSubset(
@@ -412,7 +409,6 @@ describe('Memory Model promise tests', function () {
         'age': 82
       }
     )
-
   })
 
   it('should upsert (update) Grampa again, but turn age to null', function (done) {
@@ -435,7 +431,6 @@ describe('Memory Model promise tests', function () {
         'lastName': 'Simpson'
       }
     )
-
   })
 
   it('should create mars, with two moons and a few craters', function (done) {
@@ -525,16 +520,10 @@ describe('Memory Model promise tests', function () {
           }
         )
 
-        const moons = {}
-        moons[doc.moons[0].title] = doc.moons[0]
-        moons[doc.moons[1].title] = doc.moons[1]
-        phobosId = moons['Phobos'].id
-        stickneyId = moons['Phobos'].craters[0].id
         done()
       }
     )
   })
-
 
   it('should delete Mars', function (done) {
     planetsModel.destroyById('mars')
@@ -545,6 +534,4 @@ describe('Memory Model promise tests', function () {
     return planetsModel.findById('mars')
       .then(doc => expect(doc).to.equal(undefined))
   })
-
-
 })

--- a/packages/tymly/test/memory-model-spec.js
+++ b/packages/tymly/test/memory-model-spec.js
@@ -1,0 +1,739 @@
+/* eslint-env mocha */
+
+'use strict'
+
+const chai = require('chai')
+const chaiSubset = require('chai-subset')
+chai.use(chaiSubset)
+const expect = chai.expect
+const MemoryModel = require('../lib/plugin/components/services/storage/Memory-model')
+
+describe('Run some basic tests', function () {
+  let planetsModel
+  let personModel
+  let phobosId
+  let stickneyId
+
+  it('should get some model instances', function () {
+    planetsModel = new MemoryModel(
+      {
+        'id': 'planets',
+        'name': 'planets',
+        'namespace': 'test',
+        'primaryKey': ['name'],
+        'properties': {
+          'name': 'string'
+        }
+      }
+    )
+    personModel = new MemoryModel(
+      {
+        'id': 'people',
+        'name': 'people',
+        'namespace': 'test',
+        'primaryKey': ['employeeNo'],
+        'properties': {
+          'employeeNo': 'number'
+        }
+      }
+    )
+  })
+
+  it('should create a new person', function (done) {
+    personModel.create(
+      {
+        employeeNo: 1,
+        firstName: 'Homer',
+        lastName: 'Simpson',
+        age: 39
+      },
+      {},
+      function (err, idProperties) {
+        expect(err).to.equal(null)
+        expect(idProperties).to.eql(
+          {
+            idProperties:
+            {
+              employeeNo: 1
+            }
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should create multiple new people', function (done) {
+    personModel.create(
+      [
+        {
+          employeeNo: 2,
+          firstName: 'Maggie',
+          lastName: 'Simpson'
+        },
+        {
+          employeeNo: 3,
+          firstName: 'Lisa',
+          lastName: 'Simpson',
+          age: 8
+        },
+        {
+          employeeNo: 4,
+          firstName: 'Marge',
+          lastName: 'Simpson',
+          age: 36
+        },
+        {
+          employeeNo: 5,
+          firstName: 'Bart',
+          lastName: 'Simpson',
+          age: 10
+        }
+
+      ],
+      {},
+      function (err) {
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it('should fail creating a new person with an already-used primary key', function (done) {
+    personModel.create(
+      {
+        employeeNo: 1,
+        firstName: 'Ned',
+        lastName: 'Flanders',
+        age: 60
+      },
+      {},
+      function (err, doc) {
+        expect(err).to.containSubset(
+          {
+            'name': 'DuplicatePrimaryKey'
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should fail creating new people with an already-used primary key', function (done) {
+    personModel.create(
+      [
+        {
+          employeeNo: 2,
+          firstName: 'Maude',
+          lastName: 'Flanders'
+        }
+      ],
+      {},
+      function (err, doc) {
+        expect(err).to.containSubset(
+          {
+            'name': 'DuplicatePrimaryKey'
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should find a person via primary key', function (done) {
+    personModel.findById(
+      3,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'employeeNo': 3,
+            'firstName': 'Lisa',
+            'lastName': 'Simpson',
+            'age': 8
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it("should fail finding a person that's not there", function (done) {
+    personModel.findById(
+      6,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.equal(undefined)
+        done()
+      }
+    )
+  })
+
+  it('should find 5 people', function (done) {
+    personModel.find(
+      { },
+      function (err, doc) {
+        expect(err).to.equal(null)
+
+        expect(doc).to.containSubset(
+          [
+            {
+              'age': 8,
+              'employeeNo': 3,
+              'firstName': 'Lisa',
+              'lastName': 'Simpson'
+            },
+            {
+              'age': 10,
+              'employeeNo': 5,
+              'firstName': 'Bart',
+              'lastName': 'Simpson'
+            },
+            {
+              'age': 36,
+              'employeeNo': 4,
+              'firstName': 'Marge',
+              'lastName': 'Simpson'
+            },
+            {
+              'age': 39,
+              'employeeNo': 1,
+              'firstName': 'Homer',
+              'lastName': 'Simpson'
+            },
+            {
+              'employeeNo': 2,
+              'firstName': 'Maggie',
+              'lastName': 'Simpson'
+            }
+          ]
+        )
+        done()
+      }
+    )
+  })
+
+  it('should find Bart by name', function (done) {
+    personModel.find(
+      {
+        where: {
+          firstName: {equals: 'Bart'},
+          lastName: {equals: 'Simpson'}
+        }
+      },
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.have.length(1)
+        expect(doc).to.containSubset(
+          [
+            {
+              'age': 10,
+              'employeeNo': 5,
+              'firstName': 'Bart',
+              'lastName': 'Simpson'
+            }
+          ]
+        )
+
+        done()
+      }
+    )
+  })
+
+  it('should get one Homer by name', function (done) {
+    personModel.findOne(
+      {
+        where: {
+          firstName: {equals: 'Homer'},
+          lastName: {equals: 'Simpson'}
+        }
+      },
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'age': 39,
+            'employeeNo': 1,
+            'firstName': 'Homer',
+            'lastName': 'Simpson'
+          }
+        )
+
+        done()
+      }
+    )
+  })
+
+  it("shouldn't get one missing person", function (done) {
+    personModel.findOne(
+      {
+        where: {
+          firstName: {equals: 'Ned'},
+          lastName: {equals: 'Flanders'}
+        }
+      },
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.equal(undefined)
+        done()
+      }
+    )
+  })
+
+  it("should update Maggie's age to 1", (done) => {
+    personModel.update(
+      {
+        employeeNo: 2,
+        age: 1,
+        firstName: 'Maggie',
+        lastName: 'Simpson'
+      },
+      {},
+      function (err) {
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it('should find Maggie has an age now', function (done) {
+    personModel.findById(
+      2,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'employeeNo': 2,
+            'firstName': 'Maggie',
+            'lastName': 'Simpson',
+            'age': 1
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should update Maggie again, but this time without an age', function (done) {
+    personModel.update(
+      {
+        employeeNo: 2,
+        firstName: 'Maggie',
+        lastName: 'Simpson'
+      },
+      {},
+      function (err, doc) {
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it("should find Maggie's age has gone again", function (done) {
+    personModel.findById(
+      2,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'employeeNo': 2,
+            'firstName': 'Maggie',
+            'lastName': 'Simpson'
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should patch Maggie to Margaret', function (done) {
+    personModel.patch(
+      {
+        employeeNo: 2,
+        firstName: 'Margaret'
+      },
+      {},
+      function (err, doc) {
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it('should find Maggie is now a Margaret', function (done) {
+    personModel.findById(
+      2,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'employeeNo': 2,
+            'firstName': 'Margaret',
+            'lastName': 'Simpson'
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should delete Maggie/Margaret by via her id', function (done) {
+    personModel.destroyById(
+      2,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it('should fail getting a deleted record', function (done) {
+    personModel.findById(
+      2,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.equal(undefined)
+        done()
+      }
+    )
+  })
+
+  it('should upsert (insert) Grampa', function (done) {
+    personModel.upsert(
+      {
+        employeeNo: 10,
+        firstName: 'Abe',
+        lastName: 'Simpson',
+        age: 82
+      },
+      {},
+      function (err, idProperties) {
+        expect(idProperties).to.eql(
+          {
+            idProperties: {
+              employeeNo: 10
+            }
+          }
+        )
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it('should find Grampa has been inserted via upsert', function (done) {
+    personModel.findById(
+      10,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'employeeNo': 10,
+            'firstName': 'Abe',
+            'lastName': 'Simpson',
+            'age': 82
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should upsert (update) Grampa', function (done) {
+    personModel.upsert(
+      {
+        employeeNo: 10,
+        firstName: 'Abraham',
+        lastName: 'Simpson',
+        age: 83
+      },
+      {},
+      function (err, doc) {
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it('should find Grampa has now been updates via upsert', function (done) {
+    personModel.findById(
+      10,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'employeeNo': 10,
+            'firstName': 'Abraham',
+            'lastName': 'Simpson',
+            'age': 83
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should now upsert (update) Grampa, resetting his name', function (done) {
+    personModel.upsert(
+      {
+        employeeNo: 10,
+        firstName: 'Abe'
+      },
+      {
+        setMissingPropertiesToNull: false
+      },
+      function (err, doc) {
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it('should find Grampa again, with his age preserved and an updated name', function (done) {
+    personModel.findById(
+      10,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'employeeNo': 10,
+            'firstName': 'Abe',
+            'lastName': 'Simpson',
+            'age': 83
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should upsert (update) Grampa again, but turn age to null', function (done) {
+    personModel.upsert(
+      {
+        employeeNo: 10,
+        firstName: 'Abraham',
+        lastName: 'Simpson'
+      },
+      {},
+      function (err, doc) {
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it('should find Grampa again, but now with a null age', function (done) {
+    personModel.findById(
+      10,
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'employeeNo': 10,
+            'firstName': 'Abraham',
+            'lastName': 'Simpson'
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should create mars, with two moons and a few craters', function (done) {
+    planetsModel.create(
+      {
+        name: 'mars',
+        title: 'Mars',
+        type: 'Terrestrial',
+        diameter: 6700,
+        color: 'red',
+        url: 'http://en.wikipedia.org/wiki/Mars',
+        otherFacts: {
+          radius: 3390,
+          surfacePressure: '0.636 (0.4–0.87) kPa; 0.00628 atm',
+          equatorialRotationVelocity: '868.22 km/h (241.17 m/s)'
+        },
+        moons: [
+          {
+            title: 'Phobos',
+            discoveredBy: 'Asaph Hall',
+            discoveryYear: 1800,
+            craters: [
+              {
+                title: 'Stickney',
+                diameter: 9
+              }
+            ]
+          },
+          {
+            title: 'Deimos',
+            discoveredBy: 'Asaph Hall',
+            discoveryYear: 1800
+          }
+        ]
+      },
+      {},
+      function (err, idProperties) {
+        expect(err).to.equal(null)
+        expect(idProperties).to.eql(
+          {
+            idProperties: {
+              name: 'mars'
+            }
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should find Mars via primary key', function (done) {
+    planetsModel.findById(
+      'mars',
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.containSubset(
+          {
+            'name': 'mars',
+            'title': 'Mars',
+            'type': 'Terrestrial',
+            'diameter': 6700,
+            'color': 'red',
+            'url': 'http://en.wikipedia.org/wiki/Mars',
+            'otherFacts': {
+              'radius': 3390,
+              'surfacePressure': '0.636 (0.4–0.87) kPa; 0.00628 atm',
+              'equatorialRotationVelocity': '868.22 km/h (241.17 m/s)'
+            },
+            'moons': [
+              {
+                'title': 'Phobos',
+                'discoveredBy': 'Asaph Hall',
+                'discoveryYear': 1800,
+                'craters': [
+                  {
+                    'title': 'Stickney',
+                    'diameter': 9
+                  }
+                ]
+              },
+              {
+                'title': 'Deimos',
+                'discoveredBy': 'Asaph Hall',
+                'discoveryYear': 1800
+              }
+            ]
+          }
+        )
+
+        const moons = {}
+        moons[doc.moons[0].title] = doc.moons[0]
+        moons[doc.moons[1].title] = doc.moons[1]
+        phobosId = moons['Phobos'].id
+        stickneyId = moons['Phobos'].craters[0].id
+        done()
+      }
+    )
+  })
+
+  it('should update Mars with more accurate info', function (done) {
+    planetsModel.update(
+      {
+        name: 'mars',
+        title: 'Mars',
+        type: 'Terrestrial',
+        diameter: 6779,
+        color: 'red',
+        url: 'http://en.wikipedia.org/wiki/Mars',
+        'otherFacts': {
+          'radius': 3390,
+          'surfacePressure': '0.636 (0.4–0.87) kPa; 0.00628 atm',
+          'equatorialRotationVelocity': '868.22 km/h (241.17 m/s)',
+          'lengthOfDay': '1d 0h 40m'
+        },
+        moons: [
+          {
+            id: phobosId,
+            title: 'Phobos',
+            discoveredBy: 'Asaph Hall',
+            discoveryYear: 1875,
+            craters: [
+              {
+                id: stickneyId,
+                title: 'Stickney',
+                diameter: 10
+              }
+            ]
+          }
+        ]
+      },
+      {},
+      function (err, doc) {
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it('should find updated Mars via primary key', function (done) {
+    planetsModel.findById(
+      'mars',
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc.moons).to.have.length(1)
+        expect(doc).to.containSubset(
+          {
+            'name': 'mars',
+            'title': 'Mars',
+            'type': 'Terrestrial',
+            'diameter': 6779,
+            'color': 'red',
+            'url': 'http://en.wikipedia.org/wiki/Mars',
+            'otherFacts': {
+              'radius': 3390,
+              'surfacePressure': '0.636 (0.4–0.87) kPa; 0.00628 atm',
+              'equatorialRotationVelocity': '868.22 km/h (241.17 m/s)',
+              'lengthOfDay': '1d 0h 40m'
+            },
+            'moons': [
+              {
+                id: phobosId,
+                'title': 'Phobos',
+                'discoveredBy': 'Asaph Hall',
+                'discoveryYear': 1875,
+                'craters': [
+                  {
+                    id: stickneyId,
+                    'title': 'Stickney',
+                    'diameter': 10
+                  }
+                ]
+              }
+            ]
+          }
+        )
+        done()
+      }
+    )
+  })
+
+  it('should delete Mars', function (done) {
+    planetsModel.destroyById(
+      'mars',
+      function (err, doc) {
+        expect(err).to.equal(null)
+        done()
+      }
+    )
+  })
+
+  it('should now fail to find Mars', function (done) {
+    planetsModel.findById('mars',
+      function (err, doc) {
+        expect(err).to.equal(null)
+        expect(doc).to.equal(undefined)
+        done()
+      }
+    )
+  })
+})

--- a/packages/tymly/test/memory-model-spec.js
+++ b/packages/tymly/test/memory-model-spec.js
@@ -8,7 +8,7 @@ chai.use(chaiSubset)
 const expect = chai.expect
 const MemoryModel = require('../lib/plugin/components/services/storage/Memory-model')
 
-describe('Run some basic tests', function () {
+describe('Memory Model tests', function () {
   let planetsModel
   let personModel
   let phobosId


### PR DESCRIPTION
Tymly does a lot of stuff - this is good because we need it to do stuff.

It's various interfaces are written in classical Node style - fn(arg1, arg2, callbackFn) - where the callback takes two parameters,  error and results.  Error is null/undefined if things worked.  

While established and well known, this is the doorway to callback hell.

Promises provide a path away, but rewriting all the apis to use promises would be tedious, error prone, and halt out forward progress.

This PR is an example of retrofitting an API - in this case MemoryModel and PGModel - to continue to work with callbacks (and so all the existing code) while also supporting promises.

In both cases, we have tests in the classic style and then the same set using promises.