### PR TITLE
POSTGRES extension should be quoted

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ PG_CONNECTION_STRING=postgres://postgres:postgres@localhost:5432/my_test_db
 Any database used by Tymly must be capable of generating universally unique identifiers - this is easily achieved by running the following statement on the receiving database:
 
 ```
-CREATE EXTENSION uuid-ossp;
+CREATE EXTENSION "uuid-ossp";
 ```
 
 


### PR DESCRIPTION
The example command gave the error:

    pg=# CREATE EXTENSION uuid-ossp;
    ERROR:  syntax error at or near "-"
    LINE 1: CREATE EXTENSION uuid-ossp;

resolved with quotes:

    pg=# CREATE EXTENSION "uuid-ossp";
    CREATE EXTENSION
             