### PR TITLE
build(mocha): update mocha to 4.0.1

### DIFF
--- a/blueprints/addressbase-plus-blueprint/package.json
+++ b/blueprints/addressbase-plus-blueprint/package.json
@@ -7,7 +7,7 @@
     "debug": "^2.6.8",
     "tymly": "0.0.15",
     "tymly-pg-plugin": "0.0.6",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "standard": "^10.0.3",
     "rimraf": "^2.6.2"
   },

--- a/blueprints/building-blueprint/package.json
+++ b/blueprints/building-blueprint/package.json
@@ -5,7 +5,7 @@
   "dependencies": {},
   "devDependencies": {
     "chai": "^4.1.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "standard": "^10.0.3",
     "debug": "^2.6.8",
     "tymly": "0.0.15",

--- a/blueprints/care-quality-commission-blueprint/package.json
+++ b/blueprints/care-quality-commission-blueprint/package.json
@@ -5,7 +5,7 @@
   "dependencies": {},
   "devDependencies": {
     "chai": "^4.1.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "standard": "^10.0.3",
     "debug": "^2.6.8",
     "tymly": "0.0.15",

--- a/blueprints/demo-blueprint/package.json
+++ b/blueprints/demo-blueprint/package.json
@@ -7,7 +7,7 @@
     "chai": "^4.1.0",
     "chai-subset": "^1.6.0",
     "debug": "^2.6.8",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "standard": "^10.0.3",
     "tymly": "0.0.15",
     "tymly-forms-plugin": "0.0.8",

--- a/blueprints/food-hygiene-blueprint/package.json
+++ b/blueprints/food-hygiene-blueprint/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "chai": "^4.1.0",
     "debug": "^2.6.8",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "rimraf": "^2.6.2",
     "standard": "^10.0.3",
     "tymly": "0.0.15",

--- a/blueprints/heritage-blueprint/package.json
+++ b/blueprints/heritage-blueprint/package.json
@@ -5,7 +5,7 @@
   "dependencies": {},
   "devDependencies": {
     "chai": "^4.1.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "standard": "^10.0.3",
     "debug": "^2.6.8",
     "tymly": "0.0.15",

--- a/blueprints/indices-multi-deprivation-blueprint/package.json
+++ b/blueprints/indices-multi-deprivation-blueprint/package.json
@@ -5,7 +5,7 @@
   "dependencies": {},
   "devDependencies": {
     "chai": "^4.1.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "standard": "^10.0.3",
     "debug": "^2.6.8",
     "tymly": "0.0.15",

--- a/blueprints/ofsted-blueprint/package.json
+++ b/blueprints/ofsted-blueprint/package.json
@@ -5,7 +5,7 @@
   "dependencies": {},
   "devDependencies": {
     "chai": "^4.1.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "standard": "^10.0.3",
     "debug": "^2.6.8",
     "tymly": "0.0.15",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,5 @@
   },
   "bugs": {
     "url": "https://github.com/wmfs/tymly/issues"
-  },
-  "dependencies": {
-    "mocha": "^3.5.3",
-    "standard": "^10.0.3"
   }
 }

--- a/packages/address-matcher/package.json
+++ b/packages/address-matcher/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "chai": "4.1.0",
-    "mocha": "3.5.0",
+    "mocha": "4.0.1",
     "standard": "10.0.3",
     "hl-pg-client": "0.0.1"
   },

--- a/packages/asl-choice-processor/package.json
+++ b/packages/asl-choice-processor/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "standard": "^10.0.3"
   },
   "scripts": {

--- a/packages/form-maker/package.json
+++ b/packages/form-maker/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "chai": "^4.1.0",
     "chai-subset": "^1.5.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "standard": "^10.0.3"
   },
   "scripts": {

--- a/packages/hl-pg-client/package.json
+++ b/packages/hl-pg-client/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "standard": "^10.0.3"
   },
   "scripts": {

--- a/packages/pg-concat/package.json
+++ b/packages/pg-concat/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "pg": "^6.4.1",
     "standard": "^10.0.3"
   },

--- a/packages/pg-delta-file/package.json
+++ b/packages/pg-delta-file/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "hl-pg-client": "0.0.1",
     "standard": "^10.0.3"
   },

--- a/packages/pg-diff-sync/package.json
+++ b/packages/pg-diff-sync/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "standard": "^10.0.3"
   },
   "scripts": {

--- a/packages/pg-info/package.json
+++ b/packages/pg-info/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "chai": "^4.1.0",
     "chai-subset": "^1.5.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "hl-pg-client": "0.0.1",
     "standard": "^10.0.3"
   },

--- a/packages/pg-model/package.json
+++ b/packages/pg-model/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "chai": "^4.1.0",
     "chai-subset": "^1.5.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "hl-pg-client": "0.0.1",
     "pg-diff-sync": "^0.0.11",
     "standard": "^10.0.3"

--- a/packages/pg-telepods/package.json
+++ b/packages/pg-telepods/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "hl-pg-client": "0.0.1",
     "standard": "^10.0.3"
   },

--- a/packages/relationize/package.json
+++ b/packages/relationize/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "chai": "^4.1.0",
     "chai-subset": "^1.5.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "standard": "^10.0.3"
   },
   "scripts": {

--- a/packages/smithereens/package.json
+++ b/packages/smithereens/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "chai": "^4.1.0",
     "chai-subset": "^1.5.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "standard": "^10.0.3"
   },
   "scripts": {

--- a/packages/statebox/package.json
+++ b/packages/statebox/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "chai": "^4.1.0",
     "chai-subset": "^1.5.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "standard": "^10.0.3"
   },
   "scripts": {

--- a/packages/supercopy/package.json
+++ b/packages/supercopy/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "hl-pg-client": "0.0.1",
     "standard": "^10.0.3"
   },

--- a/packages/tymly-doc-generator/package.json
+++ b/packages/tymly-doc-generator/package.json
@@ -17,7 +17,7 @@
     "upath": "^1.0.0"
   },
   "devDependencies": {
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "standard": "^10.0.3"
   },
   "scripts": {

--- a/packages/tymly-runner/package.json
+++ b/packages/tymly-runner/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "standard": "^10.0.3"
   },
   "scripts": {

--- a/packages/tymly/package.json
+++ b/packages/tymly/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "chai": "^4.1.0",
     "chai-subset": "^1.5.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "standard": "^10.0.3"
   },
   "scripts": {

--- a/packages/xml2csv/package.json
+++ b/packages/xml2csv/package.json
@@ -19,7 +19,7 @@
 	"devDependencies": {
 		"chai": "^4.1.0",
 		"chai-subset": "^1.5.0",
-		"mocha": "^3.5.0",
+		"mocha": "4.0.1",
 		"standard": "^10.0.3"
 	},
 	"scripts": {

--- a/plugins/tymly-alerts-plugin/package.json
+++ b/plugins/tymly-alerts-plugin/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "standard": "^10.0.3",
     "tymly": "^0.0.15"
   },

--- a/plugins/tymly-etl-plugin/package.json
+++ b/plugins/tymly-etl-plugin/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "chai": "^4.1.0",
     "csvtojson": "^1.1.7",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "standard": "^10.0.3",
     "tymly": "^0.0.15"
   },

--- a/plugins/tymly-express-plugin/package.json
+++ b/plugins/tymly-express-plugin/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "safe-buffer": "^5.1.1",
     "standard": "^10.0.3",
     "tymly": "0.0.15",

--- a/plugins/tymly-pg-plugin/package.json
+++ b/plugins/tymly-pg-plugin/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "chai": "^4.1.0",
     "chai-subset": "^1.6.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "rimraf": "^2.6.2",
     "standard": "^10.0.3"
   },

--- a/plugins/tymly-rankings-plugin/package.json
+++ b/plugins/tymly-rankings-plugin/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "chai": "^3.2.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "standard": "^10.0.3",
     "tymly": "^0.0.15",
     "tymly-pg-plugin": "^0.0.6",

--- a/plugins/tymly-solr-plugin/package.json
+++ b/plugins/tymly-solr-plugin/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "chai": "^3.2.0",
-    "mocha": "^3.5.0",
+    "mocha": "4.0.1",
     "standard": "^10.0.3",
     "tymly": "^0.0.15",
     "tymly-pg-plugin": "^0.0.6"

--- a/plugins/tymly-users-plugin/package.json
+++ b/plugins/tymly-users-plugin/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "chai": "4.1.2",
-    "mocha": "3.5.0",
+    "mocha": "4.0.1",
     "standard": "10.0.3",
     "tymly": "0.0.15",
     "tymly-pg-plugin": "0.0.6",

--- a/tools/tymly-packager/package.json
+++ b/tools/tymly-packager/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "chai-string": "^1.4.0",
-    "mocha": "^3.5.3",
+    "mocha": "4.0.1",
     "standard": "^10.0.3"
   },
   "dependencies": {

--- a/tools/tymly-packager/test/fixtures/packages/package-with-dependencies/plugins/package-with-dependencies/package.json
+++ b/tools/tymly-packager/test/fixtures/packages/package-with-dependencies/plugins/package-with-dependencies/package.json
@@ -12,7 +12,7 @@
     "url": "fakey://fakey"
   },
   "devDependencies": {
-    "mocha": "^3.5.3"
+    "mocha": "4.0.1"
   },
   "dependencies": {
     "rillet": "^1.11.0"


### PR DESCRIPTION
## Description
Remove `standard` and `mocha` as dependencies in the root `package.json`.

Update `mocha` to v4.0.1 across all packages and plugins (from 3.5.0 and 3.5.3).

## Motivation and Context
Resolves vulnerabilities identified in two subcomponents of the mocha
test framework:

https://nodesecurity.io/advisories/146
https://nodesecurity.io/advisories/534

## How Has This Been Tested?
`npm run test`

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
