### PR TITLE
Skip selected packages

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -46,6 +46,8 @@ async function main () {
 function packageObjCallback (gitHubPackageObj) {
   if (!gitHubPackageObj) return
 
+  if (!isTymlyPackage(gitHubPackageObj)) return
+
   const keywordToPackageMap = [
     ['package', 'packages'],
     ['plugin', 'plugins'],
@@ -55,17 +57,19 @@ function packageObjCallback (gitHubPackageObj) {
     ['mod', 'mods']
   ]
 
-  if (gitHubPackageObj.hasOwnProperty('keywords') && gitHubPackageObj.keywords.indexOf('tymly') !== -1) {
-    let lernaPackageName = null
-    const keywords = gitHubPackageObj.keywords
+  let lernaPackageName = null
+  const keywords = gitHubPackageObj.keywords
 
-    keywordToPackageMap.forEach(
-      ([keyword, packageName]) => {
-        if (keywords.indexOf(keyword) !== -1) {
-          lernaPackageName = packageName
-        }
+  keywordToPackageMap.forEach(
+    ([keyword, packageName]) => {
+      if (keywords.indexOf(keyword) !== -1) {
+        lernaPackageName = packageName
       }
-    )
-    return lernaPackageName
-  }
+    }
+  )
+  return lernaPackageName
+}
+
+function isTymlyPackage(gitHubPackageObj) {
+  return (gitHubPackageObj.keywords) && (gitHubPackageObj.keywords.indexOf('tymly') !== -1)
 }

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -48,6 +48,8 @@ function packageObjCallback (gitHubPackageObj) {
 
   if (!isTymlyPackage(gitHubPackageObj)) return
 
+  if (!shouldSync(gitHubPackageObj)) return
+
   const keywordToPackageMap = [
     ['package', 'packages'],
     ['plugin', 'plugins'],
@@ -70,6 +72,12 @@ function packageObjCallback (gitHubPackageObj) {
   return lernaPackageName
 }
 
-function isTymlyPackage(gitHubPackageObj) {
+function isTymlyPackage (gitHubPackageObj) {
   return (gitHubPackageObj.keywords) && (gitHubPackageObj.keywords.indexOf('tymly') !== -1)
+}
+
+function shouldSync (gitHubPackageObj) {
+  if (gitHubPackageObj.config && gitHubPackageObj.config.tymly)
+    return gitHubPackageObj.config.tymly.sync !== false
+  return true
 }

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -58,10 +58,11 @@ function packageObjCallback (gitHubPackageObj) {
   if (gitHubPackageObj.hasOwnProperty('keywords') && gitHubPackageObj.keywords.indexOf('tymly') !== -1) {
     let lernaPackageName = null
     const keywords = gitHubPackageObj.keywords
+
     keywordToPackageMap.forEach(
-      tuple => {
-        if (keywords.indexOf(tuple[0]) !== -1) {
-          lernaPackageName = tuple[1]
+      ([keyword, packageName]) => {
+        if (keywords.indexOf(keyword) !== -1) {
+          lernaPackageName = packageName
         }
       }
     )

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -31,30 +31,7 @@ async function main () {
       gitHubToken: process.env.TYMLY_GITHUB_TOKEN,
       gitHubOrgName: 'wmfs',
       gitHubUser: process.env.TYMLY_GITHUB_USER,
-      lernaPackageRouterFunction: function (gitHubPackageObj) {
-        if (gitHubPackageObj) {
-          const keywordToPackageMap = [
-            ['package', 'packages'],
-            ['plugin', 'plugins'],
-            ['blueprint', 'blueprints'],
-            ['cardscript', 'cardscript'],
-            ['app', 'apps'],
-            ['mod', 'mods']
-          ]
-          if (gitHubPackageObj.hasOwnProperty('keywords') && gitHubPackageObj.keywords.indexOf('tymly') !== -1) {
-            let lernaPackageName = null
-            const keywords = gitHubPackageObj.keywords
-            keywordToPackageMap.forEach(
-              tuple => {
-                if (keywords.indexOf(tuple[0]) !== -1) {
-                  lernaPackageName = tuple[1]
-                }
-              }
-            )
-            return lernaPackageName
-          }
-        }
-      }
+      lernaPackageRouterFunction: packageObjCallback
     }
   )
   await lernaSync.sync()
@@ -65,3 +42,29 @@ async function main () {
 })().catch(e => {
   console.error(e)
 })
+
+function packageObjCallback (gitHubPackageObj) {
+  if (gitHubPackageObj) {
+    const keywordToPackageMap = [
+      ['package', 'packages'],
+      ['plugin', 'plugins'],
+      ['blueprint', 'blueprints'],
+      ['cardscript', 'cardscript'],
+      ['app', 'apps'],
+      ['mod', 'mods']
+    ]
+
+    if (gitHubPackageObj.hasOwnProperty('keywords') && gitHubPackageObj.keywords.indexOf('tymly') !== -1) {
+      let lernaPackageName = null
+      const keywords = gitHubPackageObj.keywords
+      keywordToPackageMap.forEach(
+        tuple => {
+          if (keywords.indexOf(tuple[0]) !== -1) {
+            lernaPackageName = tuple[1]
+          }
+        }
+      )
+      return lernaPackageName
+    }
+  }
+}

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -44,27 +44,27 @@ async function main () {
 })
 
 function packageObjCallback (gitHubPackageObj) {
-  if (gitHubPackageObj) {
-    const keywordToPackageMap = [
-      ['package', 'packages'],
-      ['plugin', 'plugins'],
-      ['blueprint', 'blueprints'],
-      ['cardscript', 'cardscript'],
-      ['app', 'apps'],
-      ['mod', 'mods']
-    ]
+  if (!gitHubPackageObj) return
 
-    if (gitHubPackageObj.hasOwnProperty('keywords') && gitHubPackageObj.keywords.indexOf('tymly') !== -1) {
-      let lernaPackageName = null
-      const keywords = gitHubPackageObj.keywords
-      keywordToPackageMap.forEach(
-        tuple => {
-          if (keywords.indexOf(tuple[0]) !== -1) {
-            lernaPackageName = tuple[1]
-          }
+  const keywordToPackageMap = [
+    ['package', 'packages'],
+    ['plugin', 'plugins'],
+    ['blueprint', 'blueprints'],
+    ['cardscript', 'cardscript'],
+    ['app', 'apps'],
+    ['mod', 'mods']
+  ]
+
+  if (gitHubPackageObj.hasOwnProperty('keywords') && gitHubPackageObj.keywords.indexOf('tymly') !== -1) {
+    let lernaPackageName = null
+    const keywords = gitHubPackageObj.keywords
+    keywordToPackageMap.forEach(
+      tuple => {
+        if (keywords.indexOf(tuple[0]) !== -1) {
+          lernaPackageName = tuple[1]
         }
-      )
-      return lernaPackageName
-    }
+      }
+    )
+    return lernaPackageName
   }
 }


### PR DESCRIPTION
The sync will ignore Tymly packages with 

```
    "config": {
        "tymly": {
            "sync": false
        }
    }
```
 I've chosed to do it like this, rather than changing/removing keywords, is that we are sort of abusing keywords already in the sync and using "negative keywords" seemed wrong. Adding a bit in the config is essentially harmless, and no visible effects when using npm or in the package listing. 

Here's an example https://github.com/wmfs/addressbase-plus-blueprint/commit/914dc9f35023985bf619845a45258b84e014dc33